### PR TITLE
feat: ensure no transaction are lost in case ws fails

### DIFF
--- a/backend/services/txlistener/ws.go
+++ b/backend/services/txlistener/ws.go
@@ -33,7 +33,7 @@ const (
 // and subscribes to real-time transactions from both core and governance packages.
 // It uses a logical OR condition to listen to transactions from either package path
 // and submits all received transactions to the provided processor pool.
-func StartVolosTransactionListener(ctx context.Context, pool *processor.TransactionProcessorPool) error {
+func StartVolosTransactionListener(ctx context.Context, pool *processor.TransactionProcessorPool, onBlockHeight func(int)) error {
 	opts := &websocket.DialOptions{
 		Subprotocols: []string{protocol},
 	}
@@ -85,6 +85,9 @@ func StartVolosTransactionListener(ctx context.Context, pool *processor.Transact
 				if data, ok := payload["data"].(map[string]interface{}); ok {
 					if tx, ok := data["getTransactions"].(map[string]interface{}); ok {
 						pool.Submit(tx)
+						if bh, ok := tx["block_height"].(float64); ok && onBlockHeight != nil {
+							onBlockHeight(int(bh))
+						}
 						continue
 					}
 				}


### PR DESCRIPTION
how things used to work before this pr:
- websocket channel was open and backend listened for transactions continuosly
- polling system was a fallback mechanism in case ws fails, but it would start polling transactions from 0 (or whatever contract deployment block height was)
- this would result in double processing of all ws transactions

now:
- websocket updates the lastest block height processed the same way polling does so if it faills, polling system continues where ws left of
- if ws fails processing a midblock transaction, which is likely to happen, there is a small deduplication system in place which keeps track of last X processed transaction hashes (or if hashes are unavailable block_height:index string pairs). this way when ws fails, polling starts with latestblockheight - 1 and skips the already processed transactions insuring all transactions are processed exactly once