### PR TITLE
feat: market snapshotting 

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -22,7 +22,7 @@ var firestoreClient *firestore.Client
 
 func init() {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{ // TODO: switch to JSON handler for production
-		Level: slog.LevelInfo,
+		Level: slog.LevelDebug, //dev only
 	}))
 	slog.SetDefault(logger)
 

--- a/backend/model/types.go
+++ b/backend/model/types.go
@@ -98,6 +98,7 @@ type Market struct {
 	TotalBorrow      string    `firestore:"total_borrow" json:"total_borrow"`             // Total borrow amount (u256 string)
 	CurrentSupplyAPR float64   `firestore:"current_supply_apr" json:"current_supply_apr"` // Current supply APR (percentage)
 	CurrentBorrowAPR float64   `firestore:"current_borrow_apr" json:"current_borrow_apr"` // Current borrow APR (percentage)
+	UtilizationRate  float64   `firestore:"utilization_rate" json:"utilization_rate"`     // Current utilization rate (borrow/supply) as percentage
 	CreatedAt        time.Time `firestore:"created_at" json:"created_at"`                 // When the market was created
 	UpdatedAt        time.Time `firestore:"updated_at" json:"updated_at"`                 // Last time market data was updated
 }

--- a/backend/routes/market.go
+++ b/backend/routes/market.go
@@ -132,3 +132,33 @@ func GetMarketTotalSupplyHistoryHandler(client *firestore.Client) http.HandlerFu
 		json.NewEncoder(w).Encode(supplyHistory)
 	}
 }
+
+// GetMarketSnapshotsHandler handles GET /market/snapshots?marketId=ID&resolution=hourly&startTime=X&endTime=Y
+func GetMarketSnapshotsHandler(client *firestore.Client) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		marketID := r.URL.Query().Get("marketId")
+		if marketID == "" {
+			http.Error(w, "marketId query parameter is required", http.StatusBadRequest)
+			return
+		}
+
+		resolution := r.URL.Query().Get("resolution")
+		if resolution == "" {
+			resolution = "daily" // Default to daily
+		}
+
+		startTimeStr := r.URL.Query().Get("startTime")
+		endTimeStr := r.URL.Query().Get("endTime")
+
+		snapshots, err := dbfetcher.GetMarketSnapshots(client, marketID, resolution, startTimeStr, endTimeStr)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(snapshots)
+	}
+}

--- a/backend/routes/market.go
+++ b/backend/routes/market.go
@@ -155,8 +155,7 @@ func GetMarketUtilizationHistoryHandler(client *firestore.Client) http.HandlerFu
 	}
 }
 
-
-// GetMarketSnapshotsHandler handles GET /market/snapshots?marketId=ID&resolution=hourly&startTime=X&endTime=Y
+// GetMarketSnapshotsHandler handles GET /market/snapshots?marketId=ID&resolution=4hour&startTime=X&endTime=Y
 func GetMarketSnapshotsHandler(client *firestore.Client) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -169,7 +168,7 @@ func GetMarketSnapshotsHandler(client *firestore.Client) http.HandlerFunc {
 
 		resolution := r.URL.Query().Get("resolution")
 		if resolution == "" {
-			resolution = "daily" // Default to daily
+			resolution = "4hour" // Default to 4hour
 		}
 
 		startTimeStr := r.URL.Query().Get("startTime")

--- a/backend/services/aggregator/job_scheduler.go
+++ b/backend/services/aggregator/job_scheduler.go
@@ -1,0 +1,189 @@
+package aggregator
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"cloud.google.com/go/firestore"
+	"volos-backend/model"
+)
+
+// JobScheduler manages the scheduling and execution of aggregation jobs
+type JobScheduler struct {
+	client     *firestore.Client
+	aggregator *MarketAggregator
+	stopChan   chan struct{}
+}
+
+// NewJobScheduler creates a new job scheduler
+func NewJobScheduler(client *firestore.Client) *JobScheduler {
+	return &JobScheduler{
+		client:     client,
+		aggregator: NewMarketAggregator(client),
+		stopChan:   make(chan struct{}),
+	}
+}
+
+// Start begins the job scheduler
+func (js *JobScheduler) Start() {
+	go js.runHourlyJobs()
+	go js.runDailyJobs()
+	go js.runWeeklyJobs()
+	go js.runMonthlyJobs()
+
+	slog.Info("aggregation job scheduler started")
+}
+
+// Stop stops the job scheduler
+func (js *JobScheduler) Stop() {
+	close(js.stopChan)
+	slog.Info("aggregation job scheduler stopped")
+}
+
+// runHourlyJobs runs hourly aggregation jobs
+func (js *JobScheduler) runHourlyJobs() {
+	ticker := time.NewTicker(1 * time.Hour)
+	defer ticker.Stop()
+
+	// Run initial job
+	js.runHourlyAggregation()
+
+	for {
+		select {
+		case <-js.stopChan:
+			return
+		case <-ticker.C:
+			js.runHourlyAggregation()
+		}
+	}
+}
+
+// runDailyJobs runs daily aggregation jobs
+func (js *JobScheduler) runDailyJobs() {
+	ticker := time.NewTicker(24 * time.Hour)
+	defer ticker.Stop()
+
+	// Run initial job
+	js.runDailyAggregation()
+
+	for {
+		select {
+		case <-js.stopChan:
+			return
+		case <-ticker.C:
+			js.runDailyAggregation()
+		}
+	}
+}
+
+// runWeeklyJobs runs weekly aggregation jobs
+func (js *JobScheduler) runWeeklyJobs() {
+	ticker := time.NewTicker(7 * 24 * time.Hour)
+	defer ticker.Stop()
+
+	// Run initial job
+	js.runWeeklyAggregation()
+
+	for {
+		select {
+		case <-js.stopChan:
+			return
+		case <-ticker.C:
+			js.runWeeklyAggregation()
+		}
+	}
+}
+
+// runMonthlyJobs runs monthly aggregation jobs
+func (js *JobScheduler) runMonthlyJobs() {
+	ticker := time.NewTicker(30 * 24 * time.Hour) // Approximate monthly interval
+	defer ticker.Stop()
+
+	// Run initial job
+	js.runMonthlyAggregation()
+
+	for {
+		select {
+		case <-js.stopChan:
+			return
+		case <-ticker.C:
+			js.runMonthlyAggregation()
+		}
+	}
+}
+
+// runHourlyAggregation runs hourly aggregation for all markets
+func (js *JobScheduler) runHourlyAggregation() {
+	now := time.Now().Truncate(time.Hour)
+	js.runAggregationForAllMarkets(Hourly, now)
+}
+
+// runDailyAggregation runs daily aggregation for all markets
+func (js *JobScheduler) runDailyAggregation() {
+	now := time.Now().Truncate(24 * time.Hour)
+	js.runAggregationForAllMarkets(Daily, now)
+}
+
+// runWeeklyAggregation runs weekly aggregation for all markets
+func (js *JobScheduler) runWeeklyAggregation() {
+	now := time.Now().Truncate(7 * 24 * time.Hour)
+	js.runAggregationForAllMarkets(Weekly, now)
+}
+
+// runMonthlyAggregation runs monthly aggregation for all markets
+func (js *JobScheduler) runMonthlyAggregation() {
+	now := time.Now().Truncate(30 * 24 * time.Hour)
+	js.runAggregationForAllMarkets(Monthly, now)
+}
+
+// runAggregationForAllMarkets runs aggregation for all markets at the given resolution
+func (js *JobScheduler) runAggregationForAllMarkets(resolution TimeBucketResolution, timestamp time.Time) {
+	markets, err := js.getAllMarketIDs()
+	if err != nil {
+		slog.Error("failed to get market IDs for aggregation", "resolution", resolution, "error", err)
+		return
+	}
+
+	for _, marketID := range markets {
+		go func(marketID string) {
+			var err error
+			switch resolution {
+			case Hourly:
+				err = js.aggregator.CreateHourlySnapshot(marketID, timestamp)
+			case Daily:
+				err = js.aggregator.CreateDailySnapshot(marketID, timestamp)
+			case Weekly:
+				err = js.aggregator.CreateWeeklySnapshot(marketID, timestamp)
+			case Monthly:
+				err = js.aggregator.CreateMonthlySnapshot(marketID, timestamp)
+			}
+
+			if err != nil {
+				slog.Error("failed to create snapshot", "market_id", marketID, "resolution", resolution, "error", err)
+			}
+		}(marketID)
+	}
+
+	slog.Info("started aggregation jobs", "resolution", resolution, "market_count", len(markets), "timestamp", timestamp)
+}
+
+// getAllMarketIDs gets all market IDs from the database
+func (js *JobScheduler) getAllMarketIDs() ([]string, error) {
+	ctx := context.Background()
+	docs, err := js.client.Collection("markets").Documents(ctx).GetAll()
+	if err != nil {
+		return nil, err
+	}
+
+	var marketIDs []string
+	for _, doc := range docs {
+		var market model.MarketData
+		if err := doc.DataTo(&market); err != nil {
+			continue
+		}
+		marketIDs = append(marketIDs, market.ID)
+	}
+
+	return marketIDs, nil
+}

--- a/backend/services/aggregator/market_aggregator.go
+++ b/backend/services/aggregator/market_aggregator.go
@@ -1,0 +1,184 @@
+package aggregator
+
+import (
+	"context"
+	"log/slog"
+	"math/big"
+	"strings"
+	"time"
+	"volos-backend/model"
+	"volos-backend/services/utils"
+
+	"cloud.google.com/go/firestore"
+)
+
+// MarketAggregator handles the creation of time-bucket snapshots for market data
+type MarketAggregator struct {
+	client *firestore.Client
+}
+
+// NewMarketAggregator creates a new market aggregator instance
+func NewMarketAggregator(client *firestore.Client) *MarketAggregator {
+	return &MarketAggregator{
+		client: client,
+	}
+}
+
+// CreateHourlySnapshot creates an hourly snapshot for a market
+func (ma *MarketAggregator) CreateHourlySnapshot(marketID string, endTime time.Time) error {
+	startTime := endTime.Add(-1 * time.Hour)
+	return ma.createSnapshot(marketID, Hourly, startTime, endTime)
+}
+
+// CreateDailySnapshot creates a daily snapshot for a market
+func (ma *MarketAggregator) CreateDailySnapshot(marketID string, endTime time.Time) error {
+	startTime := endTime.Add(-24 * time.Hour)
+	return ma.createSnapshot(marketID, Daily, startTime, endTime)
+}
+
+// CreateWeeklySnapshot creates a weekly snapshot for a market
+func (ma *MarketAggregator) CreateWeeklySnapshot(marketID string, endTime time.Time) error {
+	startTime := endTime.Add(-7 * 24 * time.Hour)
+	return ma.createSnapshot(marketID, Weekly, startTime, endTime)
+}
+
+// CreateMonthlySnapshot creates a monthly snapshot for a market
+func (ma *MarketAggregator) CreateMonthlySnapshot(marketID string, endTime time.Time) error {
+	startTime := endTime.AddDate(0, -1, 0)
+	return ma.createSnapshot(marketID, Monthly, startTime, endTime)
+}
+
+// createSnapshot aggregates market data for the given time period and creates a snapshot
+func (ma *MarketAggregator) createSnapshot(marketID string, resolution TimeBucketResolution, startTime, endTime time.Time) error {
+	ctx := context.Background()
+	sanitizedMarketID := strings.ReplaceAll(marketID, "/", "_")
+
+	// Aggregate APR data
+	supplyAPR, borrowAPR, sampleCount, err := ma.aggregateAPRData(ctx, sanitizedMarketID, startTime, endTime)
+	if err != nil {
+		slog.Error("failed to aggregate APR data", "market_id", marketID, "error", err)
+		return err
+	}
+
+	// Get latest totals
+	totalSupply, totalBorrow, err := ma.getLatestTotals(ctx, sanitizedMarketID)
+	if err != nil {
+		slog.Error("failed to get latest totals", "market_id", marketID, "error", err)
+		return err
+	}
+
+	// Calculate utilization rate
+	utilizationRate := ma.calculateUtilizationRate(totalSupply, totalBorrow)
+
+	// Create snapshot document
+	snapshot := MarketSnapshotData{
+		MarketID:        marketID,
+		Timestamp:       endTime,
+		Resolution:      resolution,
+		SupplyAPR:       supplyAPR,
+		BorrowAPR:       borrowAPR,
+		TotalSupply:     totalSupply,
+		TotalBorrow:     totalBorrow,
+		UtilizationRate: utilizationRate,
+		SampleCount:     sampleCount,
+		CreatedAt:       time.Now(),
+	}
+
+	// Store in appropriate bucket collection
+	bucketCollection := ma.getBucketCollectionName(resolution)
+	docID := ma.generateSnapshotID(marketID, endTime, resolution)
+
+	_, err = ma.client.Collection("markets").Doc(sanitizedMarketID).Collection(bucketCollection).Doc(docID).Set(ctx, snapshot)
+	if err != nil {
+		slog.Error("failed to store market snapshot", "market_id", marketID, "resolution", resolution, "error", err)
+		return err
+	}
+
+	slog.Info("created market snapshot", "market_id", marketID, "resolution", resolution, "timestamp", endTime, "sample_count", sampleCount)
+	return nil
+}
+
+// aggregateAPRData calculates average APR values for the given time period
+func (ma *MarketAggregator) aggregateAPRData(ctx context.Context, sanitizedMarketID string, startTime, endTime time.Time) (float64, float64, int, error) {
+	aprCollection := ma.client.Collection("markets").Doc(sanitizedMarketID).Collection("apr")
+
+	query := aprCollection.Where("timestamp", ">=", startTime).Where("timestamp", "<=", endTime)
+	docs, err := query.Documents(ctx).GetAll()
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	if len(docs) == 0 {
+		return 0, 0, 0, nil
+	}
+
+	var totalSupplyAPR, totalBorrowAPR float64
+	for _, doc := range docs {
+		var aprData model.APRHistoryData
+		if err := doc.DataTo(&aprData); err != nil {
+			continue
+		}
+		totalSupplyAPR += aprData.SupplyAPR
+		totalBorrowAPR += aprData.BorrowAPR
+	}
+
+	sampleCount := len(docs)
+	avgSupplyAPR := totalSupplyAPR / float64(sampleCount)
+	avgBorrowAPR := totalBorrowAPR / float64(sampleCount)
+
+	return avgSupplyAPR, avgBorrowAPR, sampleCount, nil
+}
+
+// getLatestTotals gets the most recent total supply and borrow values
+func (ma *MarketAggregator) getLatestTotals(ctx context.Context, sanitizedMarketID string) (string, string, error) {
+	marketDoc, err := ma.client.Collection("markets").Doc(sanitizedMarketID).Get(ctx)
+	if err != nil {
+		return "0", "0", err
+	}
+
+	var market model.MarketData
+	if err := marketDoc.DataTo(&market); err != nil {
+		return "0", "0", err
+	}
+
+	return market.TotalSupply, market.TotalBorrow, nil
+}
+
+// calculateUtilizationRate calculates the utilization rate as a percentage
+func (ma *MarketAggregator) calculateUtilizationRate(totalSupply, totalBorrow string) float64 {
+	supply := utils.ParseAmount(totalSupply, "utilization calculation")
+	borrow := utils.ParseAmount(totalBorrow, "utilization calculation")
+
+	if supply.Sign() == 0 {
+		return 0
+	}
+
+	// Calculate utilization rate: (borrow / supply) * 100
+	utilization := new(big.Rat).SetFrac(borrow, supply)
+	utilizationFloat, _ := utilization.Float64()
+	return utilizationFloat * 100
+}
+
+// getBucketCollectionName returns the Firestore collection name for the given resolution
+func (ma *MarketAggregator) getBucketCollectionName(resolution TimeBucketResolution) string {
+	switch resolution {
+	case Hourly:
+		return "snapshots_hourly"
+	case Daily:
+		return "snapshots_daily"
+	case Weekly:
+		return "snapshots_weekly"
+	case Monthly:
+		return "snapshots_monthly"
+	default:
+		return "snapshots_daily"
+	}
+}
+
+// generateSnapshotID creates a unique document ID for the snapshot
+func (ma *MarketAggregator) generateSnapshotID(marketID string, timestamp time.Time, resolution TimeBucketResolution) string {
+	// Format: marketID_timestamp_resolution
+	// Example: "gno.land/r/demo/wugnot:gno.land/r/gnoswap/v1/gns:3000_2024-01-15T14:00:00Z_hourly"
+	sanitizedMarketID := strings.ReplaceAll(marketID, "/", "_")
+	return sanitizedMarketID + "_" + timestamp.Format(time.RFC3339) + "_" + string(resolution)
+}

--- a/backend/services/aggregator/types.go
+++ b/backend/services/aggregator/types.go
@@ -7,36 +7,35 @@ import (
 type TimeBucketResolution string
 
 const (
-	Hourly  TimeBucketResolution = "hourly"
-	Daily   TimeBucketResolution = "daily"
-	Weekly  TimeBucketResolution = "weekly"
-	Monthly TimeBucketResolution = "monthly"
+	FourHour TimeBucketResolution = "4hour"
+	Daily    TimeBucketResolution = "daily"
+	ThreeDay TimeBucketResolution = "3day"
 )
 
 // MarketSnapshotData represents a pre-aggregated snapshot of market data at a specific time resolution.
 // These snapshots are stored in bucket collections to enable fast queries for different timeframes.
 type MarketSnapshotData struct {
-	MarketID        string              `firestore:"market_id" json:"market_id"`               // Market identifier
-	Timestamp       time.Time           `firestore:"timestamp" json:"timestamp"`               // When this snapshot was taken
-	Resolution      TimeBucketResolution `firestore:"resolution" json:"resolution"`            // Time resolution (hourly, daily, weekly, monthly)
-	SupplyAPR       float64             `firestore:"supply_apr" json:"supply_apr"`             // Average supply APR for this period
-	BorrowAPR       float64             `firestore:"borrow_apr" json:"borrow_apr"`             // Average borrow APR for this period
-	TotalSupply     string              `firestore:"total_supply" json:"total_supply"`         // Total supply at end of period (u256 string)
-	TotalBorrow     string              `firestore:"total_borrow" json:"total_borrow"`         // Total borrow at end of period (u256 string)
-	UtilizationRate float64             `firestore:"utilization_rate" json:"utilization_rate"` // Utilization rate (borrow/supply) as percentage
-	SampleCount     int                 `firestore:"sample_count" json:"sample_count"`         // Number of samples used for averaging
-	CreatedAt       time.Time           `firestore:"created_at" json:"created_at"`             // When this snapshot was created
+	MarketID        string               `firestore:"market_id" json:"market_id"`               // Market identifier
+	Timestamp       time.Time            `firestore:"timestamp" json:"timestamp"`               // When this snapshot was taken
+	Resolution      TimeBucketResolution `firestore:"resolution" json:"resolution"`             // Time resolution (4hour, daily, 3day)
+	SupplyAPR       float64              `firestore:"supply_apr" json:"supply_apr"`             // Average supply APR for this period
+	BorrowAPR       float64              `firestore:"borrow_apr" json:"borrow_apr"`             // Average borrow APR for this period
+	TotalSupply     string               `firestore:"total_supply" json:"total_supply"`         // Total supply at end of period (u256 string)
+	TotalBorrow     string               `firestore:"total_borrow" json:"total_borrow"`         // Total borrow at end of period (u256 string)
+	UtilizationRate float64              `firestore:"utilization_rate" json:"utilization_rate"` // Utilization rate (borrow/supply) as percentage
+	SampleCount     int                  `firestore:"sample_count" json:"sample_count"`         // Number of samples used for averaging
+	CreatedAt       time.Time            `firestore:"created_at" json:"created_at"`             // When this snapshot was created
 }
 
 // AggregationJob represents a scheduled job for creating market snapshots
 type AggregationJob struct {
-	ID           string              `firestore:"id" json:"id"`                     // Unique job identifier
-	MarketID     string              `firestore:"market_id" json:"market_id"`       // Market to aggregate
-	Resolution   TimeBucketResolution `firestore:"resolution" json:"resolution"`    // Time resolution
-	StartTime    time.Time           `firestore:"start_time" json:"start_time"`     // Start of aggregation period
-	EndTime      time.Time           `firestore:"end_time" json:"end_time"`         // End of aggregation period
-	Status       string              `firestore:"status" json:"status"`             // Job status: "pending", "running", "completed", "failed"
-	CreatedAt    time.Time           `firestore:"created_at" json:"created_at"`     // When job was created
-	CompletedAt  *time.Time          `firestore:"completed_at" json:"completed_at"` // When job completed (if applicable)
-	ErrorMessage string              `firestore:"error_message" json:"error_message"` // Error message if failed
+	ID           string               `firestore:"id" json:"id"`                       // Unique job identifier
+	MarketID     string               `firestore:"market_id" json:"market_id"`         // Market to aggregate
+	Resolution   TimeBucketResolution `firestore:"resolution" json:"resolution"`       // Time resolution
+	StartTime    time.Time            `firestore:"start_time" json:"start_time"`       // Start of aggregation period
+	EndTime      time.Time            `firestore:"end_time" json:"end_time"`           // End of aggregation period
+	Status       string               `firestore:"status" json:"status"`               // Job status: "pending", "running", "completed", "failed"
+	CreatedAt    time.Time            `firestore:"created_at" json:"created_at"`       // When job was created
+	CompletedAt  *time.Time           `firestore:"completed_at" json:"completed_at"`   // When job completed (if applicable)
+	ErrorMessage string               `firestore:"error_message" json:"error_message"` // Error message if failed
 }

--- a/backend/services/aggregator/types.go
+++ b/backend/services/aggregator/types.go
@@ -1,0 +1,42 @@
+package aggregator
+
+import (
+	"time"
+)
+
+type TimeBucketResolution string
+
+const (
+	Hourly  TimeBucketResolution = "hourly"
+	Daily   TimeBucketResolution = "daily"
+	Weekly  TimeBucketResolution = "weekly"
+	Monthly TimeBucketResolution = "monthly"
+)
+
+// MarketSnapshotData represents a pre-aggregated snapshot of market data at a specific time resolution.
+// These snapshots are stored in bucket collections to enable fast queries for different timeframes.
+type MarketSnapshotData struct {
+	MarketID        string              `firestore:"market_id" json:"market_id"`               // Market identifier
+	Timestamp       time.Time           `firestore:"timestamp" json:"timestamp"`               // When this snapshot was taken
+	Resolution      TimeBucketResolution `firestore:"resolution" json:"resolution"`            // Time resolution (hourly, daily, weekly, monthly)
+	SupplyAPR       float64             `firestore:"supply_apr" json:"supply_apr"`             // Average supply APR for this period
+	BorrowAPR       float64             `firestore:"borrow_apr" json:"borrow_apr"`             // Average borrow APR for this period
+	TotalSupply     string              `firestore:"total_supply" json:"total_supply"`         // Total supply at end of period (u256 string)
+	TotalBorrow     string              `firestore:"total_borrow" json:"total_borrow"`         // Total borrow at end of period (u256 string)
+	UtilizationRate float64             `firestore:"utilization_rate" json:"utilization_rate"` // Utilization rate (borrow/supply) as percentage
+	SampleCount     int                 `firestore:"sample_count" json:"sample_count"`         // Number of samples used for averaging
+	CreatedAt       time.Time           `firestore:"created_at" json:"created_at"`             // When this snapshot was created
+}
+
+// AggregationJob represents a scheduled job for creating market snapshots
+type AggregationJob struct {
+	ID           string              `firestore:"id" json:"id"`                     // Unique job identifier
+	MarketID     string              `firestore:"market_id" json:"market_id"`       // Market to aggregate
+	Resolution   TimeBucketResolution `firestore:"resolution" json:"resolution"`    // Time resolution
+	StartTime    time.Time           `firestore:"start_time" json:"start_time"`     // Start of aggregation period
+	EndTime      time.Time           `firestore:"end_time" json:"end_time"`         // End of aggregation period
+	Status       string              `firestore:"status" json:"status"`             // Job status: "pending", "running", "completed", "failed"
+	CreatedAt    time.Time           `firestore:"created_at" json:"created_at"`     // When job was created
+	CompletedAt  *time.Time          `firestore:"completed_at" json:"completed_at"` // When job completed (if applicable)
+	ErrorMessage string              `firestore:"error_message" json:"error_message"` // Error message if failed
+}

--- a/backend/services/aggregator/types.go
+++ b/backend/services/aggregator/types.go
@@ -9,7 +9,7 @@ type TimeBucketResolution string
 const (
 	FourHour TimeBucketResolution = "4hour"
 	Daily    TimeBucketResolution = "daily"
-	ThreeDay TimeBucketResolution = "3day"
+	Weekly   TimeBucketResolution = "weekly"
 )
 
 // MarketSnapshotData represents a pre-aggregated snapshot of market data at a specific time resolution.
@@ -17,13 +17,12 @@ const (
 type MarketSnapshotData struct {
 	MarketID        string               `firestore:"market_id" json:"market_id"`               // Market identifier
 	Timestamp       time.Time            `firestore:"timestamp" json:"timestamp"`               // When this snapshot was taken
-	Resolution      TimeBucketResolution `firestore:"resolution" json:"resolution"`             // Time resolution (4hour, daily, 3day)
+	Resolution      TimeBucketResolution `firestore:"resolution" json:"resolution"`             // Time resolution (4hour, daily, weekly)
 	SupplyAPR       float64              `firestore:"supply_apr" json:"supply_apr"`             // Average supply APR for this period
 	BorrowAPR       float64              `firestore:"borrow_apr" json:"borrow_apr"`             // Average borrow APR for this period
 	TotalSupply     string               `firestore:"total_supply" json:"total_supply"`         // Total supply at end of period (u256 string)
 	TotalBorrow     string               `firestore:"total_borrow" json:"total_borrow"`         // Total borrow at end of period (u256 string)
 	UtilizationRate float64              `firestore:"utilization_rate" json:"utilization_rate"` // Utilization rate (borrow/supply) as percentage
-	SampleCount     int                  `firestore:"sample_count" json:"sample_count"`         // Number of samples used for averaging
 	CreatedAt       time.Time            `firestore:"created_at" json:"created_at"`             // When this snapshot was created
 }
 

--- a/backend/services/dbfetcher/market.go
+++ b/backend/services/dbfetcher/market.go
@@ -197,14 +197,12 @@ func GetMarketSnapshots(client *firestore.Client, marketID, resolution, startTim
 
 	var bucketCollection string
 	switch resolution {
-	case "hourly":
-		bucketCollection = "snapshots_hourly"
+	case "4hour":
+		bucketCollection = "snapshots_4hour"
 	case "daily":
 		bucketCollection = "snapshots_daily"
-	case "weekly":
-		bucketCollection = "snapshots_weekly"
-	case "monthly":
-		bucketCollection = "snapshots_monthly"
+	case "3day":
+		bucketCollection = "snapshots_3day"
 	default:
 		bucketCollection = "snapshots_daily"
 	}

--- a/backend/services/dbfetcher/market.go
+++ b/backend/services/dbfetcher/market.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"log/slog"
 	"strings"
-	"time"
 
 	"volos-backend/model"
 	"volos-backend/services/aggregator"
+	"volos-backend/services/utils"
 
 	"cloud.google.com/go/firestore"
 )
@@ -165,77 +165,6 @@ func GetMarketTotalSupplyHistory(client *firestore.Client, marketID string) ([]m
 	return dataArray, nil
 }
 
-// GetMarketSnapshots retrieves aggregated market snapshots for a specific time period
-func GetMarketSnapshots(client *firestore.Client, marketID, resolution, startTimeStr, endTimeStr string) ([]aggregator.MarketSnapshotData, error) {
-	ctx := context.Background()
-	sanitizedMarketID := strings.ReplaceAll(marketID, "/", "_")
-
-	// Determine bucket collection based on resolution
-	var bucketCollection string
-	switch resolution {
-	case "hourly":
-		bucketCollection = "snapshots_hourly"
-	case "daily":
-		bucketCollection = "snapshots_daily"
-	case "weekly":
-		bucketCollection = "snapshots_weekly"
-	case "monthly":
-		bucketCollection = "snapshots_monthly"
-	default:
-		bucketCollection = "snapshots_daily"
-	}
-
-	// Parse time range
-	var startTime, endTime time.Time
-	var err error
-
-	if startTimeStr != "" {
-		startTime, err = time.Parse(time.RFC3339, startTimeStr)
-		if err != nil {
-			slog.Error("failed to parse start time", "start_time", startTimeStr, "error", err)
-			return nil, err
-		}
-	}
-
-	if endTimeStr != "" {
-		endTime, err = time.Parse(time.RFC3339, endTimeStr)
-		if err != nil {
-			slog.Error("failed to parse end time", "end_time", endTimeStr, "error", err)
-			return nil, err
-		}
-	}
-
-	// Build query
-	query := client.Collection("markets").Doc(sanitizedMarketID).Collection(bucketCollection).OrderBy("timestamp", firestore.Asc)
-
-	if !startTime.IsZero() {
-		query = query.Where("timestamp", ">=", startTime)
-	}
-
-	if !endTime.IsZero() {
-		query = query.Where("timestamp", "<=", endTime)
-	}
-
-	// Execute query
-	docs, err := query.Documents(ctx).GetAll()
-	if err != nil {
-		slog.Error("Error fetching market snapshots", "market_id", marketID, "resolution", resolution, "error", err)
-		return nil, err
-	}
-
-	var snapshots []aggregator.MarketSnapshotData
-	for _, doc := range docs {
-		var snapshot aggregator.MarketSnapshotData
-		if err := doc.DataTo(&snapshot); err != nil {
-			slog.Error("Error parsing snapshot data", "market_id", marketID, "doc_id", doc.Ref.ID, "error", err)
-			continue
-		}
-		snapshots = append(snapshots, snapshot)
-	}
-
-	return snapshots, nil
-}
-
 // GetMarketUtilizationHistory retrieves utilization history data for a specific market
 func GetMarketUtilizationHistory(client *firestore.Client, marketID string) ([]model.UtilizationHistory, error) {
 	ctx := context.Background()
@@ -259,4 +188,55 @@ func GetMarketUtilizationHistory(client *firestore.Client, marketID string) ([]m
 	}
 
 	return dataArray, nil
+}
+
+// GetMarketSnapshots retrieves aggregated market snapshots for a specific time period
+func GetMarketSnapshots(client *firestore.Client, marketID, resolution, startTimeStr, endTimeStr string) ([]aggregator.MarketSnapshotData, error) {
+	ctx := context.Background()
+	sanitizedMarketID := strings.ReplaceAll(marketID, "/", "_")
+
+	var bucketCollection string
+	switch resolution {
+	case "hourly":
+		bucketCollection = "snapshots_hourly"
+	case "daily":
+		bucketCollection = "snapshots_daily"
+	case "weekly":
+		bucketCollection = "snapshots_weekly"
+	case "monthly":
+		bucketCollection = "snapshots_monthly"
+	default:
+		bucketCollection = "snapshots_daily"
+	}
+
+	startTime := utils.ParseTime(startTimeStr, "market snapshots query")
+	endTime := utils.ParseTime(endTimeStr, "market snapshots query")
+
+	query := client.Collection("markets").Doc(sanitizedMarketID).Collection(bucketCollection).OrderBy("timestamp", firestore.Asc)
+
+	if !startTime.IsZero() {
+		query = query.Where("timestamp", ">=", startTime)
+	}
+
+	if !endTime.IsZero() {
+		query = query.Where("timestamp", "<=", endTime)
+	}
+
+	docs, err := query.Documents(ctx).GetAll()
+	if err != nil {
+		slog.Error("Error fetching market snapshots", "market_id", marketID, "resolution", resolution, "error", err)
+		return nil, err
+	}
+
+	var snapshots []aggregator.MarketSnapshotData
+	for _, doc := range docs {
+		var snapshot aggregator.MarketSnapshotData
+		if err := doc.DataTo(&snapshot); err != nil {
+			slog.Error("Error parsing snapshot data", "market_id", marketID, "doc_id", doc.Ref.ID, "error", err)
+			continue
+		}
+		snapshots = append(snapshots, snapshot)
+	}
+
+	return snapshots, nil
 }

--- a/backend/services/dbfetcher/market.go
+++ b/backend/services/dbfetcher/market.go
@@ -201,8 +201,8 @@ func GetMarketSnapshots(client *firestore.Client, marketID, resolution, startTim
 		bucketCollection = "snapshots_4hour"
 	case "daily":
 		bucketCollection = "snapshots_daily"
-	case "3day":
-		bucketCollection = "snapshots_3day"
+	case "weekly":
+		bucketCollection = "snapshots_weekly"
 	default:
 		bucketCollection = "snapshots_daily"
 	}

--- a/backend/services/utils/parsing.go
+++ b/backend/services/utils/parsing.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"math/big"
 	"strconv"
+	"time"
 )
 
 // ParseTimestamp parses a timestamp string to int64, logs errors and returns 0 on failure
@@ -47,6 +48,21 @@ func ParseInt64(value string, context string) int64 {
 	if err != nil {
 		slog.Error("failed to parse int64", "context", context, "value", value, "error", err)
 		return 0
+	}
+	return parsed
+}
+
+// ParseTime parses a time string in RFC3339 format, logs errors and returns zero time on failure
+func ParseTime(timeStr string, context string) time.Time {
+	if timeStr == "" {
+		slog.Error("Empty time string", "context", context)
+		return time.Time{}
+	}
+
+	parsed, err := time.Parse(time.RFC3339, timeStr)
+	if err != nil {
+		slog.Error("failed to parse time", "context", context, "time", timeStr, "error", err)
+		return time.Time{}
 	}
 	return parsed
 }


### PR DESCRIPTION
adds a package named `aggregator` that serves a purpose to snapshot the market in fixed timeframes (4 hours, daily and weekly).
market has subcollections that store every events values in separate docs. if we were to used these collection for graph purposes for example we could end up in a situation where a market has an average 1000 loan token supplies in an hour (figuratively speaking) which would result in 24 000 points in a graph that display the total supply in a day (let alone week or month). 

this is why market is being snapshot on a fixed time frame, so these snapshots can be a representation of whatever timeframe (with these 3 precisions) without overloading the client side 