### PR TITLE
feat(frontend): add some abci calls 

### DIFF
--- a/frontend/app/(app)/governance/delegates/page.tsx
+++ b/frontend/app/(app)/governance/delegates/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useUser, useUserPendingUnstakes, useWithdrawUnstakedVLSMutation } from "@/app/(app)/governance/queries-mutations"
-import { useUserAddress } from "@/app/utils/address.utils"
+import { useUserAddress } from "@/hooks/use-user-address"
 import { DelegateForm } from "@/components/delegate-form"
 import { DelegateeCard } from "@/components/delegatee-card"
 import { PendingUnstakeCard } from "@/components/pending-unstake-card"

--- a/frontend/app/services/abci.ts
+++ b/frontend/app/services/abci.ts
@@ -12,9 +12,6 @@ const GOVERNANCE_REALM_PATH = "gno.land/r/volos/gov/governance"
 const XVLS_REALM_PATH = "gno.land/r/volos/gov/xvls"
 const gnoService = GnoService.getInstance()
 
-
-// GOVERNANCE API QUERIES
-
 export async function apiGetUserInfo(userAddr: string): Promise<GovernanceUserInfo> {
   try {
     const result = await gnoService.evaluateExpression(

--- a/frontend/app/services/abci.ts
+++ b/frontend/app/services/abci.ts
@@ -6,6 +6,7 @@ import {
 } from "../types"
 import { parseABCIResponse, parseValidatedJsonResult } from "../utils/parsing.utils"
 import { GnoService } from "./abci.service"
+import { VOLOS_ADDRESS } from "./tx.service"
 
 const GOVERNANCE_REALM_PATH = "gno.land/r/volos/gov/governance"
 const XVLS_REALM_PATH = "gno.land/r/volos/gov/xvls"
@@ -46,6 +47,19 @@ export async function getTokenBalance(tokenPath: string, userAddress: string): P
     const result = await gnoService.evaluateExpression(
       tokenPath,
       `BalanceOf("${userAddress}")`,
+    )
+    return parseABCIResponse(result, 'int64')
+  } catch (error) {
+    console.error('Error fetching token balance:', error)
+    throw error
+  }
+}
+
+export async function getAllowance(tokenPath: string, userAddress: string): Promise<string> {
+  try {
+    const result = await gnoService.evaluateExpression(
+      tokenPath,
+      `Allowance("${userAddress}", "${VOLOS_ADDRESS}")`,
     )
     return parseABCIResponse(result, 'int64')
   } catch (error) {

--- a/frontend/app/services/abci.ts
+++ b/frontend/app/services/abci.ts
@@ -1,10 +1,10 @@
 import {
-  GovernanceUserInfo,
-  GovernanceUserInfoSchema,
   Balance,
   BalanceSchema,
+  GovernanceUserInfo,
+  GovernanceUserInfoSchema,
 } from "../types"
-import { parseValidatedJsonResult } from "../utils/parsing.utils"
+import { parseABCIResponse, parseValidatedJsonResult } from "../utils/parsing.utils"
 import { GnoService } from "./abci.service"
 
 const GOVERNANCE_REALM_PATH = "gno.land/r/volos/gov/governance"
@@ -37,6 +37,19 @@ export async function apiGetXVLSBalance(userAddr: string): Promise<Balance> {
     return balanceData
   } catch (error) {
     console.error('Error fetching xVLS balance:', error)
+    throw error
+  }
+}
+
+export async function getTokenBalance(tokenPath: string, userAddress: string): Promise<string> {
+  try {
+    const result = await gnoService.evaluateExpression(
+      tokenPath,
+      `BalanceOf("${userAddress}")`,
+    )
+    return parseABCIResponse(result, 'int64')
+  } catch (error) {
+    console.error('Error fetching token balance:', error)
     throw error
   }
 }

--- a/frontend/components/add-borrow-panel.tsx
+++ b/frontend/components/add-borrow-panel.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useApproveTokenMutation, useBorrowMutation, usePositionQuery, useSupplyCollateralMutation } from "@/app/(app)/borrow/queries-mutations"
+import { getTokenBalance } from "@/app/services/abci"
 import { MarketInfo } from "@/app/types"
 import { PositionCard } from "@/components/position-card"
 import { SidePanelCard } from "@/components/side-panel-card"
@@ -35,7 +36,6 @@ export function AddBorrowPanel({
     positionMetrics,
     currentCollateral,
     currentBorrowAssets,
-    maxBorrow,
     calculateMaxBorrowable,
     healthFactor
   } = usePositionCalculations(positionData ?? {
@@ -160,8 +160,14 @@ export function AddBorrowPanel({
         buttonMessage={supplyButtonMessage}
         isButtonDisabled={isSupplyInputEmpty || isSupplyTooManyDecimals || isSupplyPending}
         isButtonPending={isSupplyPending}
-        onMaxClickAction={() => {
-          setValue("supplyAmount", formatUnits(maxBorrow, market.loanTokenDecimals));
+        onMaxClickAction={async () => {
+          try {
+            const balance = await getTokenBalance(market.collateralToken!, userAddress!);
+            const balanceFormatted = formatUnits(BigInt(balance), market.collateralTokenDecimals);
+            setValue("supplyAmount", balanceFormatted);
+          } catch (error) {
+            console.error("Failed to fetch collateral balance:", error);
+          }
         }}
         onSubmitAction={handleSupply}
         inputValue={supplyAmount}

--- a/frontend/components/add-borrow-panel.tsx
+++ b/frontend/components/add-borrow-panel.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useApproveTokenMutation, useBorrowMutation, usePositionQuery, useSupplyCollateralMutation } from "@/app/(app)/borrow/queries-mutations"
-import { getTokenBalance } from "@/app/services/abci"
+import { getAllowance, getTokenBalance } from "@/app/services/abci"
 import { MarketInfo } from "@/app/types"
 import { PositionCard } from "@/components/position-card"
 import { SidePanelCard } from "@/components/side-panel-card"
@@ -87,17 +87,22 @@ export function AddBorrowPanel({
     if (isSupplyInputEmpty || isSupplyTooManyDecimals) return;
     
     const supplyAmountInTokens = Number(supplyAmount || "0");
+    const supplyAmountInDenom = supplyAmountInTokens * Math.pow(10, market.collateralTokenDecimals);
     
     try {
-      await approveTokenMutation.mutateAsync({
-        tokenPath: market.collateralToken!,
-        amount: supplyAmountInTokens * Math.pow(10, market.collateralTokenDecimals)
-      });
+      const currentAllowance = BigInt(await getAllowance(market.collateralToken!, userAddress!));
+      
+      if (currentAllowance < BigInt(supplyAmountInDenom)) {
+        await approveTokenMutation.mutateAsync({
+          tokenPath: market.collateralToken!,
+          amount: supplyAmountInDenom
+        });
+      }
       
       await supplyCollateralMutation.mutateAsync({
         marketId: market.poolPath!,
         userAddress: userAddress!,
-        amount: supplyAmountInTokens * Math.pow(10, market.collateralTokenDecimals)
+        amount: supplyAmountInDenom
       });
       
       reset();
@@ -110,17 +115,22 @@ export function AddBorrowPanel({
     if (isBorrowInputEmpty || isBorrowTooManyDecimals || isBorrowOverMax) return;
     
     const borrowAmountInTokens = Number(borrowAmount || "0");
+    const borrowAmountInDenom = borrowAmountInTokens * Math.pow(10, market.loanTokenDecimals);
     
     try {
-      await approveTokenMutation.mutateAsync({
-        tokenPath: market.loanToken!,
-        amount: borrowAmountInTokens * Math.pow(10, market.loanTokenDecimals)
-      });
+      const currentAllowance = BigInt(await getAllowance(market.loanToken!, userAddress!));
+      
+      if (currentAllowance < BigInt(borrowAmountInDenom)) {
+        await approveTokenMutation.mutateAsync({
+          tokenPath: market.loanToken!,
+          amount: borrowAmountInDenom
+        });
+      }
       
       await borrowMutation.mutateAsync({
         marketId: market.poolPath!,
         userAddress: userAddress!,
-        assets: borrowAmountInTokens * Math.pow(10, market.loanTokenDecimals)
+        assets: borrowAmountInDenom
       });
       
       reset();

--- a/frontend/components/delegate-form.tsx
+++ b/frontend/components/delegate-form.tsx
@@ -2,7 +2,7 @@
 
 import { useApproveVLSMutation, useStakeVLSMutation } from "@/app/(app)/governance/queries-mutations"
 import { STAKER_PKG_PATH } from "@/app/services/tx.service"
-import { useUserAddress } from "@/app/utils/address.utils"
+import { useUserAddress } from "@/hooks/use-user-address"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { ChevronDown, ChevronUp, Plus } from "lucide-react"

--- a/frontend/components/gov-member-cards.tsx
+++ b/frontend/components/gov-member-cards.tsx
@@ -1,5 +1,6 @@
 import { useApproveVLSMutation, useGovernanceUserInfo, useStakeVLSMutation } from "@/app/(app)/governance/queries-mutations"
-import { STAKER_PKG_PATH } from "@/app/services/tx.service"
+import { getAllowance } from "@/app/services/abci"
+import { STAKER_PKG_PATH, VLS_PKG_PATH } from "@/app/services/tx.service"
 import { formatTokenAmount } from "@/app/utils/format.utils"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -53,10 +54,14 @@ export function GovMemberCards({
 
     setIsStaking(true)
     try {
-      await approveVLSMutation.mutateAsync({
-        spender: STAKER_PKG_PATH,
-        amount: amountInDenom
-      })
+      const currentAllowance = BigInt(await getAllowance(VLS_PKG_PATH, userAddress!))
+      
+      if (currentAllowance < BigInt(amountInDenom)) {
+        await approveVLSMutation.mutateAsync({
+          spender: STAKER_PKG_PATH,
+          amount: amountInDenom
+        })
+      }
 
       await stakeVLSMutation.mutateAsync({
         amount: amountInDenom,

--- a/frontend/components/supply-borrow-chart.tsx
+++ b/frontend/components/supply-borrow-chart.tsx
@@ -153,7 +153,7 @@ export function SupplyBorrowChart({
                   return String(key)
                 }}
                 height={50}
-                interval="preserveStartEnd"
+                interval={3}
                 tick={{ textAnchor: 'start', fill: 'rgb(156 163 175)' }}
                 tickMargin={5}
                 stroke="rgba(75, 85, 99, 0.3)"

--- a/frontend/components/supply-panel.tsx
+++ b/frontend/components/supply-panel.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useApproveTokenMutation, usePositionQuery, useSupplyMutation, useWithdrawMutation } from "@/app/(app)/borrow/queries-mutations"
+import { getTokenBalance } from "@/app/services/abci"
 import { MarketInfo } from "@/app/types"
 import { calculateMaxWithdrawable } from "@/app/utils/position.utils"
 import { SidePanelCard } from "@/components/side-panel-card"
@@ -118,9 +119,14 @@ export function SupplyPanel({
         buttonMessage={supplyButtonMessage}
         isButtonDisabled={isSupplyInputEmpty || isSupplyTooManyDecimals || isSupplyPending}
         isButtonPending={isSupplyPending}
-        onMaxClickAction={() => {
-          // TODO: use ABCI
-          setValue("supplyAmount", "0");
+        onMaxClickAction={async () => {
+          try {
+            const balance = await getTokenBalance(market.loanToken!, userAddress!);
+            const balanceFormatted = formatUnits(BigInt(balance), market.loanTokenDecimals);
+            setValue("supplyAmount", balanceFormatted);
+          } catch (error) {
+            console.error("Failed to fetch loan balance:", error);
+          }
         }}
         onSubmitAction={handleSupply}
         inputValue={supplyAmount}

--- a/frontend/components/supply-panel.tsx
+++ b/frontend/components/supply-panel.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useApproveTokenMutation, usePositionQuery, useSupplyMutation, useWithdrawMutation } from "@/app/(app)/borrow/queries-mutations"
-import { getTokenBalance } from "@/app/services/abci"
+import { getAllowance, getTokenBalance } from "@/app/services/abci"
 import { MarketInfo } from "@/app/types"
 import { calculateMaxWithdrawable } from "@/app/utils/position.utils"
 import { SidePanelCard } from "@/components/side-panel-card"
@@ -63,17 +63,22 @@ export function SupplyPanel({
     if (isSupplyInputEmpty || isSupplyTooManyDecimals) return;
     
     const supplyAmountInTokens = Number(supplyAmount || "0");
+    const supplyAmountInDenom = supplyAmountInTokens * Math.pow(10, market.loanTokenDecimals);
     
     try {
-      await approveTokenMutation.mutateAsync({
-        tokenPath: market.loanToken!,
-        amount: supplyAmountInTokens * Math.pow(10, market.loanTokenDecimals)
-      });
+      const currentAllowance = BigInt(await getAllowance(market.loanToken!, userAddress!));
+      
+      if (currentAllowance < BigInt(supplyAmountInDenom)) {
+        await approveTokenMutation.mutateAsync({
+          tokenPath: market.loanToken!,
+          amount: supplyAmountInDenom
+        });
+      }
       
       await supplyMutation.mutateAsync({
         marketId: market.poolPath!,
         userAddress: userAddress!,
-        assets: supplyAmountInTokens * Math.pow(10, market.loanTokenDecimals)
+        assets: supplyAmountInDenom
       });
       
       reset();
@@ -86,17 +91,22 @@ export function SupplyPanel({
     if (isWithdrawInputEmpty || isWithdrawTooManyDecimals || isWithdrawOverMax) return;
     
     const withdrawAmountInTokens = Number(withdrawAmount || "0");
+    const withdrawAmountInDenom = withdrawAmountInTokens * Math.pow(10, market.loanTokenDecimals);
     
     try {
-      await approveTokenMutation.mutateAsync({
-        tokenPath: market.loanToken!,
-        amount: withdrawAmountInTokens * Math.pow(10, market.loanTokenDecimals)
-      });
+      const currentAllowance = BigInt(await getAllowance(market.loanToken!, userAddress!));
+      
+      if (currentAllowance < BigInt(withdrawAmountInDenom)) {
+        await approveTokenMutation.mutateAsync({
+          tokenPath: market.loanToken!,
+          amount: withdrawAmountInDenom
+        });
+      }
       
       await withdrawMutation.mutateAsync({
         marketId: market.poolPath!,
         userAddress: userAddress!,
-        assets: withdrawAmountInTokens * Math.pow(10, market.loanTokenDecimals)
+        assets: withdrawAmountInDenom
       });
       
       reset();

--- a/frontend/components/utilization-apr-chart.tsx
+++ b/frontend/components/utilization-apr-chart.tsx
@@ -147,7 +147,7 @@ export function UtilizationAPRChart({
                   return key
                 }}
                 height={50}
-                interval={0}
+                interval={3}
                 tick={{ textAnchor: 'start', fill: 'rgb(156 163 175)' }}
                 tickMargin={5}
                 stroke="rgba(75, 85, 99, 0.3)"


### PR DESCRIPTION
#53 
- adds abci calls when users clicks on max buttons for supplying collateral and loan tokens, which retrieves his balance
- adds abci call to check allowance so user never has to add more allowance than necessary for improved security (doesn't affect performance at all)

- also fixes some ticks on graphs so if you don't agree pls don't close, request changes