### PR TITLE
feat: prie polling

### DIFF
--- a/backend/model/types.go
+++ b/backend/model/types.go
@@ -100,6 +100,7 @@ type Market struct {
 	UpdatedAt               time.Time `firestore:"updated_at" json:"updated_at"`                               // Last time market data was updated
 	LLTV                    string    `firestore:"lltv" json:"lltv"`                                           // Liquidation Loan-to-Value ratio (WAD-scaled, e.g., 75% = 0.75 * 1e18)
 	Fee                     string    `firestore:"fee" json:"fee"`                                             // Market fee (u256 string)
+	PoolPath                string    `firestore:"pool_path" json:"pool_path"`                                 // Gnoswap pool id (e.g. "token0:token1:3000")
 }
 
 // APRHistory represents a single APR history entry stored in the apr subcollection.

--- a/backend/services/dbupdater/gnoswap.go
+++ b/backend/services/dbupdater/gnoswap.go
@@ -12,6 +12,12 @@ import (
 // poolPath is extracted from the provided marketID by removing the ":0" or ":1" suffix
 // Uses Firestore transaction to atomically fetch markets, get token decimals, and update prices
 func UpdatePrice(firestoreClient *firestore.Client, sqrtPriceX96, marketID string) {
+	println("==========================")
+	println("UpdatePrice called")
+	println("sqrtPriceX96:", sqrtPriceX96)
+	println("marketID:", marketID)
+	println("==========================")
+
 	if sqrtPriceX96 == "" || marketID == "" {
 		slog.Error("missing sqrtPriceX96 or marketID for price update", "sqrtPriceX96", sqrtPriceX96, "marketID", marketID)
 		return
@@ -20,10 +26,15 @@ func UpdatePrice(firestoreClient *firestore.Client, sqrtPriceX96, marketID strin
 	poolPath := strings.TrimSuffix(strings.TrimSuffix(marketID, ":0"), ":1")
 	revert := strings.HasSuffix(marketID, ":1")
 
+	println("==========================")
+	println("poolPath:", poolPath)
+	println("revert:", revert)
+	println("==========================")
+
 	ctx := context.Background()
 	marketsRef := firestoreClient.Collection("markets")
 
-	iter := marketsRef.Where("poolPath", "==", poolPath).Documents(ctx)
+	iter := marketsRef.Where("pool_path", "==", poolPath).Documents(ctx)
 	defer iter.Stop()
 
 	var marketDocs []*firestore.DocumentSnapshot
@@ -35,8 +46,16 @@ func UpdatePrice(firestoreClient *firestore.Client, sqrtPriceX96, marketID strin
 		marketDocs = append(marketDocs, doc)
 	}
 
+	println("==========================")
+	println("Found", len(marketDocs), "market documents")
+	println("==========================")
+
 	err := firestoreClient.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
 		for _, marketDoc := range marketDocs {
+			println("==========================")
+			println("Processing market:", marketDoc.Ref.ID)
+			println("==========================")
+
 			loanTokenDecimals, err := marketDoc.DataAt("loan_token_decimals")
 			if err != nil {
 				slog.Error("failed to get loan_token_decimals", "market_id", marketDoc.Ref.ID, "error", err)
@@ -49,11 +68,20 @@ func UpdatePrice(firestoreClient *firestore.Client, sqrtPriceX96, marketID strin
 				continue
 			}
 
+			println("==========================")
+			println("loanTokenDecimals:", loanTokenDecimals)
+			println("collateralTokenDecimals:", collateralTokenDecimals)
+			println("==========================")
+
 			price := extractPriceFromSqrt(sqrtPriceX96, revert, loanTokenDecimals.(int64), collateralTokenDecimals.(int64))
 			if price == "" {
 				slog.Error("failed to extract price", "sqrtPriceX96", sqrtPriceX96, "market_id", marketDoc.Ref.ID)
 				continue
 			}
+
+			println("==========================")
+			println("Calculated price:", price)
+			println("==========================")
 
 			if err := tx.Update(marketDoc.Ref, []firestore.Update{{Path: "current_price", Value: price}}); err != nil {
 				slog.Error("failed to update market price", "market_id", marketDoc.Ref.ID, "error", err)
@@ -67,7 +95,14 @@ func UpdatePrice(firestoreClient *firestore.Client, sqrtPriceX96, marketID strin
 	})
 
 	if err != nil {
+		println("==========================")
+		println("Transaction failed:", err.Error())
+		println("==========================")
 		slog.Error("transaction failed for price update", "poolPath", poolPath, "marketID", marketID, "error", err)
 		return
 	}
+
+	println("==========================")
+	println("UpdatePrice completed successfully")
+	println("==========================")
 }

--- a/backend/services/dbupdater/market.go
+++ b/backend/services/dbupdater/market.go
@@ -54,6 +54,7 @@ func CreateMarket(client *firestore.Client,
 
 	marketData := map[string]interface{}{
 		"id":                        marketID,
+		"pool_path":                 poolPath,
 		"loan_token":                loanToken,
 		"collateral_token":          collateralToken,
 		"loan_token_name":           loanTokenName,

--- a/frontend/app/(app)/borrow/[marketId]/page.tsx
+++ b/frontend/app/(app)/borrow/[marketId]/page.tsx
@@ -29,7 +29,7 @@ function MarketPageContent() {
     <div className="items-center justify-center space-y-6 -mt-6 py-6 relative">
       <h1 className="text-[36px] font-bold mb-6 text-gray-300">
         {!isMarketLoading && marketInfo
-          ? `${marketInfo.loanTokenSymbol} / ${marketInfo.collateralTokenSymbol.toUpperCase()} Market`
+          ? `${marketInfo.loan_token_symbol} / ${marketInfo.collateral_token_symbol.toUpperCase()} Market`
           : <span className="animate-pulse bg-gray-700 rounded-xl w-96 h-15 inline-block mt-4" />}
       </h1>
       

--- a/frontend/app/(app)/borrow/columns.tsx
+++ b/frontend/app/(app)/borrow/columns.tsx
@@ -1,21 +1,21 @@
 "use client"
 
-import { MarketInfo } from "@/app/types"
+import { Market } from "@/app/types"
 import { formatPercentage, parseTokenAmount, wadToPercentage } from "@/app/utils/format.utils"
 import { Button } from "@/components/ui/button"
 import { ColumnDef } from "@tanstack/react-table"
 import { ArrowUpDown } from "lucide-react"
 
-export const columns: ColumnDef<MarketInfo>[] = [
+export const columns: ColumnDef<Market>[] = [
   {
-    accessorKey: "loanTokenSymbol",
+    accessorKey: "loan_token_symbol",
     header: () => {
       return (
         <div className="text-left px-3">Loan Asset</div>
       )
     },
     cell: ({ row }) => {
-      const loanSymbol = row.original.loanTokenSymbol
+      const loanSymbol = row.original.loan_token_symbol
       
       return (
         <div className="flex items-center text-left px-3">
@@ -25,14 +25,14 @@ export const columns: ColumnDef<MarketInfo>[] = [
     },
   },
   {
-    accessorKey: "collateralTokenSymbol",
+    accessorKey: "collateral_token_symbol",
     header: () => {
       return (
         <div className="text-left px-3">Collateral Asset</div>
       )
     },
     cell: ({ row }) => {
-      const collateralSymbol = row.original.collateralTokenSymbol
+      const collateralSymbol = row.original.collateral_token_symbol
       
       return (
         <div className="flex items-center text-left px-3">
@@ -58,7 +58,7 @@ export const columns: ColumnDef<MarketInfo>[] = [
       )
     },
     cell: ({ row }) => {
-      return <div className="text-left font-medium px-3">{parseTokenAmount(row.original.totalSupplyAssets, row.original.loanTokenDecimals)} {row.original.loanTokenSymbol}</div>
+      return <div className="text-left font-medium px-3">{parseTokenAmount(row.original.total_supply, row.original.loan_token_decimals)} {row.original.loan_token_symbol}</div>
     },
   },
   {
@@ -78,7 +78,7 @@ export const columns: ColumnDef<MarketInfo>[] = [
       )
     },
     cell: ({ row }) => {
-      return <div className="text-left font-medium px-3">{parseTokenAmount(row.original.totalBorrowAssets, row.original.loanTokenDecimals)} {row.original.loanTokenSymbol}</div>
+      return <div className="text-left font-medium px-3">{parseTokenAmount(row.original.total_borrow, row.original.loan_token_decimals)} {row.original.loan_token_symbol}</div>
     },
   },
   {
@@ -98,7 +98,7 @@ export const columns: ColumnDef<MarketInfo>[] = [
       )
     },
     cell: ({ row }) => {
-      return <div className="text-left font-medium px-3">{formatPercentage(wadToPercentage(row.original.supplyAPR))}</div>
+      return <div className="text-left font-medium px-3">{formatPercentage(wadToPercentage(row.original.supply_apr))}</div>
     },
   },
   {
@@ -118,7 +118,7 @@ export const columns: ColumnDef<MarketInfo>[] = [
       )
     },
     cell: ({ row }) => {
-      return <div className="text-left font-medium px-3">{formatPercentage(wadToPercentage(row.original.borrowAPR))}</div>
+      return <div className="text-left font-medium px-3">{formatPercentage(wadToPercentage(row.original.borrow_apr))}</div>
     },
   },
   {

--- a/frontend/app/(app)/borrow/queries-mutations.ts
+++ b/frontend/app/(app)/borrow/queries-mutations.ts
@@ -1,11 +1,10 @@
 import { getAPRHistory, getBorrowHistory, getCollateralSupplyHistory, getMarket, getMarketActivity, getMarkets, getMarketSnapshots, getSupplyHistory, getUserLoanHistory, getUserMarketPosition, getUtilizationHistory } from "@/app/services/api.service";
 import { TxService, VOLOS_ADDRESS } from "@/app/services/tx.service";
-import { HealthFactor, MarketInfo, Position } from "@/app/types";
+import { HealthFactor, Market, Position } from "@/app/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 export const marketsQueryKey = ["markets"];
 export const marketQueryKey = (marketId: string) => ["market", marketId];
-export const marketPriceQueryKey = (marketId: string) => ["marketPrice", marketId];
 export const marketHistoryQueryKey = (marketId: string) => ["marketHistory", marketId];
 export const healthFactorQueryKey = (marketId: string, user: string) => ["healthFactor", marketId, user];
 export const positionQueryKey = (marketId: string, user: string) => ["position", marketId, user];
@@ -21,44 +20,9 @@ export const userLoanHistoryQueryKey = (userAddress: string) => ["userLoanHistor
 export function useMarketsQuery() {
   return useQuery({
     queryKey: marketsQueryKey,
-    queryFn: async (): Promise<MarketInfo[]> => {
+    queryFn: async (): Promise<Market[]> => {
       const response = await getMarkets();
-      
-      // Transform API Market to MarketInfo format
-      const markets: MarketInfo[] = response.markets.map(market => ({
-        // Market fields
-        totalSupplyAssets: market.total_supply,
-        totalSupplyShares: market.total_supply_shares,
-        totalBorrowAssets: market.total_borrow,
-        totalBorrowShares: market.total_borrow_shares,
-        fee: market.fee,
-        
-        // Params fields
-        poolPath: market.id, // TODO: Extract pool path from market ID
-        irm: "default", // TODO: Get actual IRM from market data
-        lltv: market.lltv,
-        
-        // Additional fields
-        loanToken: market.loan_token,
-        collateralToken: market.collateral_token,
-        currentPrice: market.current_price,
-        borrowAPR: market.borrow_apr,
-        supplyAPR: market.supply_apr,
-        utilization: market.utilization_rate,
-        
-        // Token information fields
-        loanTokenName: market.loan_token_name,
-        loanTokenSymbol: market.loan_token_symbol,
-        loanTokenDecimals: market.loan_token_decimals,
-        
-        collateralTokenName: market.collateral_token_name,
-        collateralTokenSymbol: market.collateral_token_symbol,
-        collateralTokenDecimals: market.collateral_token_decimals,
-        
-        marketId: market.id,
-      }));
-      
-      return markets;
+      return response.markets;
     },
   });
 }
@@ -75,42 +39,8 @@ export function useUserLoanHistoryQuery(userAddress: string) {
 export function useMarketQuery(marketId: string) {
   return useQuery({
     queryKey: marketQueryKey(marketId),
-    queryFn: async (): Promise<MarketInfo> => {
-      const market = await getMarket(marketId);
-      
-      // Transform API Market to MarketInfo format
-      return {
-        // Market fields
-        totalSupplyAssets: market.total_supply,
-        totalSupplyShares: market.total_supply_shares,
-        totalBorrowAssets: market.total_borrow,
-        totalBorrowShares: market.total_borrow_shares,
-        fee: market.fee,
-        
-        // Params fields
-        poolPath: market.id, // TODO: Extract pool path from market ID
-        irm: "default", // TODO: Get actual IRM from market data
-        lltv: market.lltv,
-        
-        // Additional fields
-        loanToken: market.loan_token,
-        collateralToken: market.collateral_token,
-        currentPrice: market.current_price,
-        borrowAPR: market.borrow_apr,
-        supplyAPR: market.supply_apr,
-        utilization: market.utilization_rate,
-        
-        // Token information fields
-        loanTokenName: market.loan_token_name,
-        loanTokenSymbol: market.loan_token_symbol,
-        loanTokenDecimals: market.loan_token_decimals,
-        
-        collateralTokenName: market.collateral_token_name,
-        collateralTokenSymbol: market.collateral_token_symbol,
-        collateralTokenDecimals: market.collateral_token_decimals,
-        
-        marketId: market.id,
-      };
+    queryFn: async (): Promise<Market> => {
+      return await getMarket(marketId);
     },
     enabled: !!marketId,
     refetchInterval: 2000, //TODO: REMOVE POLLING, SWITCH TO WEBSOCKETS 

--- a/frontend/app/(app)/borrow/queries-mutations.ts
+++ b/frontend/app/(app)/borrow/queries-mutations.ts
@@ -5,6 +5,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 export const marketsQueryKey = ["markets"];
 export const marketQueryKey = (marketId: string) => ["market", marketId];
+export const marketPriceQueryKey = (marketId: string) => ["marketPrice", marketId];
 export const marketHistoryQueryKey = (marketId: string) => ["marketHistory", marketId];
 export const healthFactorQueryKey = (marketId: string, user: string) => ["healthFactor", marketId, user];
 export const positionQueryKey = (marketId: string, user: string) => ["position", marketId, user];
@@ -112,6 +113,9 @@ export function useMarketQuery(marketId: string) {
       };
     },
     enabled: !!marketId,
+    refetchInterval: 2000,
+    refetchIntervalInBackground: true,
+    staleTime: 1000,
   });
 }
 

--- a/frontend/app/(app)/borrow/queries-mutations.ts
+++ b/frontend/app/(app)/borrow/queries-mutations.ts
@@ -113,7 +113,7 @@ export function useMarketQuery(marketId: string) {
       };
     },
     enabled: !!marketId,
-    refetchInterval: 2000,
+    refetchInterval: 2000, //TODO: REMOVE POLLING, SWITCH TO WEBSOCKETS 
     refetchIntervalInBackground: true,
     staleTime: 1000,
   });

--- a/frontend/app/types.ts
+++ b/frontend/app/types.ts
@@ -159,13 +159,14 @@ export const MarketSchema = z.object({
   total_collateral_supply: Uint256Schema,
   supply_apr: Uint256Schema,
   borrow_apr: Uint256Schema,
-  utilization_rate: Uint256Schema,
+  utilization: Uint256Schema,
   total_borrow_shares: Uint256Schema,
   total_supply_shares: Uint256Schema,
   created_at: z.string(),
   updated_at: z.string(),
   lltv: Uint256Schema,
   fee: Uint256Schema,
+  pool_path: z.string(),
 });
 
 export const MarketsResponseSchema = z.object({
@@ -180,34 +181,6 @@ export const MarketActivityResponseSchema = z.object({
   last_id: z.string(),
 });
 
-export const MarketInfoSchema = z.object({
-  totalSupplyAssets: Uint256Schema,
-  totalSupplyShares: Uint256Schema,
-  totalBorrowAssets: Uint256Schema,
-  totalBorrowShares: Uint256Schema,
-  fee: Uint256Schema,
-  
-  poolPath: z.string(),
-  irm: z.string(),
-  lltv: Uint256Schema,
-    
-  loanToken: z.string(),
-  collateralToken: z.string(),
-  currentPrice: z.string(),
-  borrowAPR: Uint256Schema,
-  supplyAPR: Uint256Schema,
-  utilization: Uint256Schema,
-  
-  loanTokenName: z.string(),
-  loanTokenSymbol: z.string(),
-  loanTokenDecimals: z.number().int(),
-  
-  collateralTokenName: z.string(),
-  collateralTokenSymbol: z.string(),
-  collateralTokenDecimals: z.number().int(),
-  
-  marketId: z.string().optional(),
-});
 
 export const GovernanceUserInfoSchema = z.object({
   address: z.string(),
@@ -244,7 +217,6 @@ export type PendingUnstake = z.infer<typeof PendingUnstakeSchema>;
 export type Market = z.infer<typeof MarketSchema>;
 export type MarketsResponse = z.infer<typeof MarketsResponseSchema>;
 export type MarketActivityResponse = z.infer<typeof MarketActivityResponseSchema>;
-export type MarketInfo = z.infer<typeof MarketInfoSchema>;
 export type GovernanceUserInfo = z.infer<typeof GovernanceUserInfoSchema>;
 export type HealthFactor = z.infer<typeof HealthFactorSchema>;
 export type Balance = z.infer<typeof BalanceSchema>;

--- a/frontend/app/utils/position.utils.ts
+++ b/frontend/app/utils/position.utils.ts
@@ -1,4 +1,4 @@
-import { MarketInfo, Position } from "@/app/types";
+import { Market, Position } from "@/app/types";
 import { WAD } from "./format.utils";
 
 // Virtual amounts for share/asset calculations (matching contract values)
@@ -40,7 +40,7 @@ export function toAssetsUp(shares: bigint, totalAssets: bigint, totalShares: big
  * @param market Market information
  * @returns Object containing maxBorrow (as BigInt), healthFactor, and LTV (both as numbers)
  */
-export function calculatePositionMetrics(position: Position, market: MarketInfo | undefined): {
+export function calculatePositionMetrics(position: Position, market: Market | undefined): {
   maxBorrow: bigint;
   healthFactor: number;
   ltv: number;
@@ -56,15 +56,15 @@ export function calculatePositionMetrics(position: Position, market: MarketInfo 
   const borrowShares = BigInt(position.borrow_shares || "0");
   const collateralAmount = BigInt(position.collateral_supply || "0");
   
-  const totalBorrowAssets = BigInt(market.totalBorrowAssets || "0");
-  const totalBorrowShares = BigInt(market.totalBorrowShares || "0");
+  const totalBorrowAssets = BigInt(market.total_borrow || "0");
+  const totalBorrowShares = BigInt(market.total_borrow_shares || "0");
   
   // Calculate actual borrow amount from shares
   const borrowAmount = borrowShares > BigInt(0) && totalBorrowShares > BigInt(0) 
     ? toAssetsDown(borrowShares, totalBorrowAssets, totalBorrowShares)
     : BigInt(0);
   
-  const currentPrice = BigInt(market.currentPrice || "0");
+  const currentPrice = BigInt(market.current_price || "0");
 
   // Parse LLTV - convert percentage to WAD-scaled value
   // market.LLTV is stored as percentage (e.g., 75 for 75%)
@@ -127,7 +127,7 @@ export function calculatePositionMetrics(position: Position, market: MarketInfo 
  * @param market Market information
  * @returns Maximum borrowable amount as BigInt
  */
-export function calculateMaxBorrowable(position: Position, market: MarketInfo | undefined): bigint {
+export function calculateMaxBorrowable(position: Position, market: Market | undefined): bigint {
   const { maxBorrow } = calculatePositionMetrics(position, market);
   
   if (!market) {
@@ -135,8 +135,8 @@ export function calculateMaxBorrowable(position: Position, market: MarketInfo | 
   }
   
   const borrowShares = BigInt(position.borrow_shares || "0");
-  const totalBorrowAssets = BigInt(market.totalBorrowAssets || "0");
-  const totalBorrowShares = BigInt(market.totalBorrowShares || "0");
+  const totalBorrowAssets = BigInt(market.total_borrow || "0");
+  const totalBorrowShares = BigInt(market.total_borrow_shares || "0");
   
   const currentBorrow = borrowShares > BigInt(0) && totalBorrowShares > BigInt(0) 
     ? toAssetsDown(borrowShares, totalBorrowAssets, totalBorrowShares)
@@ -156,14 +156,14 @@ export function calculateMaxBorrowable(position: Position, market: MarketInfo | 
  * @param market Market information
  * @returns Maximum withdrawable amount as BigInt
  */
-export function calculateMaxWithdrawable(position: Position, market: MarketInfo | undefined): bigint {
+export function calculateMaxWithdrawable(position: Position, market: Market | undefined): bigint {
   if (!market) {
     return BigInt(0);
   }
   
   const supplyShares = BigInt(position.supply_shares || "0");
-  const totalSupplyAssets = BigInt(market.totalSupplyAssets || "0");
-  const totalSupplyShares = BigInt(market.totalSupplyShares || "0");
+  const totalSupplyAssets = BigInt(market.total_supply || "0");
+  const totalSupplyShares = BigInt(market.total_supply_shares || "0");
   
   if (supplyShares === BigInt(0) || totalSupplyShares === BigInt(0)) {
     return BigInt(0);

--- a/frontend/components/add-borrow-panel.tsx
+++ b/frontend/components/add-borrow-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useApproveTokenMutation, useBorrowMutation, usePositionQuery, useSupplyCollateralMutation } from "@/app/(app)/borrow/queries-mutations"
 import { getAllowance, getTokenBalance } from "@/app/services/abci"
-import { MarketInfo } from "@/app/types"
+import { Market } from "@/app/types"
 import { PositionCard } from "@/components/position-card"
 import { SidePanelCard } from "@/components/side-panel-card"
 import { useFormValidation } from "@/hooks/use-borrow-validation"
@@ -13,7 +13,7 @@ import { useForm } from "react-hook-form"
 import { formatUnits } from "viem"
 
 interface AddBorrowPanelProps {
-  market: MarketInfo
+  market: Market
 }
 
 export function AddBorrowPanel({
@@ -30,7 +30,7 @@ export function AddBorrowPanel({
   })
 
   const { userAddress } = useUserAddress()
-  const { data: positionData, refetch: refetchPosition } = usePositionQuery(market.poolPath!, userAddress)
+  const { data: positionData, refetch: refetchPosition } = usePositionQuery(market.pool_path, userAddress)
   
   const {
     positionMetrics,
@@ -73,7 +73,7 @@ export function AddBorrowPanel({
       const { data: latestPosition } = await refetchPosition()
       
       if (latestPosition) {
-        const maxBorrowableStr = formatUnits(positionMetrics.maxBorrow, market.loanTokenDecimals)
+        const maxBorrowableStr = formatUnits(positionMetrics.maxBorrow, market.loan_token_decimals)
         setValue("borrowAmount", maxBorrowableStr)
       }
     } catch (error) {
@@ -85,20 +85,20 @@ export function AddBorrowPanel({
     if (isSupplyInputEmpty || isSupplyTooManyDecimals) return;
     
     const supplyAmountInTokens = Number(supplyAmount || "0");
-    const supplyAmountInDenom = supplyAmountInTokens * Math.pow(10, market.collateralTokenDecimals);
+    const supplyAmountInDenom = supplyAmountInTokens * Math.pow(10, market.collateral_token_decimals);
     
     try {
-      const currentAllowance = BigInt(await getAllowance(market.collateralToken!, userAddress!));
+      const currentAllowance = BigInt(await getAllowance(market.collateral_token, userAddress!));
       
       if (currentAllowance < BigInt(supplyAmountInDenom)) {
         await approveTokenMutation.mutateAsync({
-          tokenPath: market.collateralToken!,
+          tokenPath: market.collateral_token,
           amount: supplyAmountInDenom
         });
       }
       
       await supplyCollateralMutation.mutateAsync({
-        marketId: market.poolPath!,
+        marketId: market.pool_path,
         userAddress: userAddress!,
         amount: supplyAmountInDenom
       });
@@ -113,20 +113,20 @@ export function AddBorrowPanel({
     if (isBorrowInputEmpty || isBorrowTooManyDecimals || isBorrowOverMax) return;
     
     const borrowAmountInTokens = Number(borrowAmount || "0");
-    const borrowAmountInDenom = borrowAmountInTokens * Math.pow(10, market.loanTokenDecimals);
+    const borrowAmountInDenom = borrowAmountInTokens * Math.pow(10, market.loan_token_decimals);
     
     try {
-      const currentAllowance = BigInt(await getAllowance(market.loanToken!, userAddress!));
+      const currentAllowance = BigInt(await getAllowance(market.loan_token, userAddress!));
       
       if (currentAllowance < BigInt(borrowAmountInDenom)) {
         await approveTokenMutation.mutateAsync({
-          tokenPath: market.loanToken!,
+          tokenPath: market.loan_token,
           amount: borrowAmountInDenom
         });
       }
       
       await borrowMutation.mutateAsync({
-        marketId: market.poolPath!,
+        marketId: market.pool_path,
         userAddress: userAddress!,
         assets: borrowAmountInDenom
       });
@@ -143,11 +143,11 @@ export function AddBorrowPanel({
       <SidePanelCard
         icon={ArrowDown}
         iconColor="text-purple-400"
-        title={`Borrow ${market.loanTokenSymbol}`}
+        title={`Borrow ${market.loan_token_symbol}`}
         register={register}
         fieldName="borrowAmount"
-        tokenSymbol={market.loanTokenSymbol}
-        currentBalanceFormatted={formatUnits(currentBorrowAssets, market.loanTokenDecimals)}
+        tokenSymbol={market.loan_token_symbol}
+        currentBalanceFormatted={formatUnits(currentBorrowAssets, market.loan_token_decimals)}
         buttonMessage={borrowButtonMessage}
         isButtonDisabled={isBorrowInputEmpty || isBorrowTooManyDecimals || isBorrowOverMax || isBorrowPending}
         isButtonPending={isBorrowPending}
@@ -160,18 +160,18 @@ export function AddBorrowPanel({
       <SidePanelCard
         icon={Plus}
         iconColor="text-blue-400"
-        title={`Supply Collateral ${market.collateralTokenSymbol}`}
+        title={`Supply Collateral ${market.collateral_token_symbol}`}
         register={register}
         fieldName="supplyAmount"
-        tokenSymbol={market.collateralTokenSymbol}
-        currentBalanceFormatted={formatUnits(currentCollateral, market.collateralTokenDecimals)}
+        tokenSymbol={market.collateral_token_symbol}
+        currentBalanceFormatted={formatUnits(currentCollateral, market.collateral_token_decimals)}
         buttonMessage={supplyButtonMessage}
         isButtonDisabled={isSupplyInputEmpty || isSupplyTooManyDecimals || isSupplyPending}
         isButtonPending={isSupplyPending}
         onMaxClickAction={async () => {
           try {
-            const balance = await getTokenBalance(market.collateralToken!, userAddress!);
-            const balanceFormatted = formatUnits(BigInt(balance), market.collateralTokenDecimals);
+            const balance = await getTokenBalance(market.collateral_token, userAddress!);
+            const balanceFormatted = formatUnits(BigInt(balance), market.collateral_token_decimals);
             setValue("supplyAmount", balanceFormatted);
           } catch (error) {
             console.error("Failed to fetch collateral balance:", error);
@@ -187,8 +187,8 @@ export function AddBorrowPanel({
         supplyAmount={supplyAmount}
         borrowAmount={borrowAmount}
         healthFactor={healthFactor}
-        currentCollateral={formatUnits(currentCollateral, market.collateralTokenDecimals)}
-        currentBorrowAssets={formatUnits(currentBorrowAssets, market.loanTokenDecimals)}
+        currentCollateral={formatUnits(currentCollateral, market.collateral_token_decimals)}
+        currentBorrowAssets={formatUnits(currentBorrowAssets, market.loan_token_decimals)}
       />
     </form>
   )

--- a/frontend/components/market-dashboard.tsx
+++ b/frontend/components/market-dashboard.tsx
@@ -1,8 +1,8 @@
-import { MarketInfo } from "@/app/types";
+import { Market } from "@/app/types";
 import { formatPercentage, formatTokenAmount, wadToPercentage } from "@/app/utils/format.utils";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 interface MarketDashboardProps {
-  market: MarketInfo;
+  market: Market;
   cardStyles: string;
 }
 
@@ -21,13 +21,13 @@ export function MarketDashboard({ market, cardStyles }: MarketDashboardProps) {
           {/* Loan Token */}
           <div className="flex items-center">
             <div className="w-10 h-10 rounded-full bg-blue-500/20 flex items-center justify-center mr-3">
-              <span className="text-blue-400 font-bold">{market.loanTokenSymbol.charAt(0)}</span>
+              <span className="text-blue-400 font-bold">{market.loan_token_symbol.charAt(0)}</span>
             </div>
             <div className="flex-1">
               <div className="text-xs text-gray-400">Loan Token</div>
               <div className="font-medium text-gray-200 flex items-center">
-                {market.loanTokenName} 
-                <span className="ml-1 text-gray-400 text-[10px]">({market.loanTokenSymbol})</span>
+                {market.loan_token_name} 
+                <span className="ml-1 text-gray-400 text-[10px]">({market.loan_token_symbol})</span>
               </div>
             </div>
           </div>
@@ -35,13 +35,13 @@ export function MarketDashboard({ market, cardStyles }: MarketDashboardProps) {
           {/* Collateral Token */}
           <div className="flex items-center">
             <div className="w-10 h-10 rounded-full bg-purple-500/20 flex items-center justify-center mr-3">
-              <span className="text-purple-400 font-bold">{market.collateralTokenSymbol.charAt(0)}</span>
+              <span className="text-purple-400 font-bold">{market.collateral_token_symbol.charAt(0)}</span>
             </div>
             <div className="flex-1">
               <div className="text-xs text-gray-400">Collateral Token</div>
               <div className="font-medium text-gray-200 flex items-center">
-                {market.collateralTokenName}
-                <span className="ml-1 text-gray-400 text-[10px]">({market.collateralTokenSymbol})</span>
+                {market.collateral_token_name}
+                <span className="ml-1 text-gray-400 text-[10px]">({market.collateral_token_symbol})</span>
               </div>
             </div>
           </div>
@@ -51,12 +51,12 @@ export function MarketDashboard({ market, cardStyles }: MarketDashboardProps) {
             <div className="flex items-center gap-2">
               <div className="text-xs text-gray-400">Current Price</div>
               <span className="text-[10px] font-light text-gray-400">
-                ({market.loanTokenSymbol} / {market.collateralTokenSymbol})
+                ({market.loan_token_symbol} / {market.collateral_token_symbol})
               </span>
             </div>
             <div className="flex items-baseline flex-wrap">
               <span className="text-2xl font-bold text-gray-200 break-all">
-                {formatTokenAmount(market.currentPrice, 36, 2, 6)}
+                {formatTokenAmount(market.current_price, 36, 2, 6)}
               </span>
             </div>
           </div>
@@ -76,7 +76,7 @@ export function MarketDashboard({ market, cardStyles }: MarketDashboardProps) {
           <div>
             <div className="text-xs text-gray-400 mb-0.5">Total Supply</div>
             <div className="text-2xl font-bold text-gray-200">
-              {formatTokenAmount(market.totalSupplyAssets, market.loanTokenDecimals)} <span className="text-gray-400 text-base">{market.loanTokenSymbol}</span>
+              {formatTokenAmount(market.total_supply, market.loan_token_decimals)} <span className="text-gray-400 text-base">{market.loan_token_symbol}</span>
             </div>
           </div>
           
@@ -84,7 +84,7 @@ export function MarketDashboard({ market, cardStyles }: MarketDashboardProps) {
           <div>
             <div className="text-xs text-gray-400 mb-0.5">Total Borrow</div>
             <div className="text-2xl font-bold text-gray-200">
-              {formatTokenAmount(market.totalBorrowAssets, market.loanTokenDecimals)} <span className="text-gray-400 text-base">{market.loanTokenSymbol}</span>
+              {formatTokenAmount(market.total_borrow, market.loan_token_decimals)} <span className="text-gray-400 text-base">{market.loan_token_symbol}</span>
             </div>
           </div>
           
@@ -120,13 +120,13 @@ export function MarketDashboard({ market, cardStyles }: MarketDashboardProps) {
             <div>
               <div className="text-xs text-gray-400 mb-0.5">Supply APR</div>
               <div className="text-2xl text-gray-200">
-                {formatPercentage(wadToPercentage(market.supplyAPR, 2))}
+                {formatPercentage(wadToPercentage(market.supply_apr, 2))}
               </div>
             </div>
             <div>
               <div className="text-xs text-gray-400 mb-0.5">Borrow APR</div>
               <div className="text-2xl text-gray-200">
-                {formatPercentage(wadToPercentage(market.borrowAPR, 2))}
+                {formatPercentage(wadToPercentage(market.borrow_apr, 2))}
               </div>
             </div>
           </div>

--- a/frontend/components/market-overview.tsx
+++ b/frontend/components/market-overview.tsx
@@ -1,11 +1,11 @@
-import { MarketInfo } from "@/app/types";
+import { Market } from "@/app/types";
+import { formatPercentage, wadToPercentage } from "@/app/utils/format.utils";
 import { InfoCard } from "@/components/info-card";
 import { SupplyBorrowChart } from "./supply-borrow-chart";
 import { UtilizationAPRChart } from "./utilization-apr-chart";
-import { formatPercentage, wadToPercentage } from "@/app/utils/format.utils";
 
 interface MarketOverviewProps {
-  market: MarketInfo;
+  market: Market;
   apyVariations: {
     sevenDay: number;
     ninetyDay: number;
@@ -24,20 +24,20 @@ export function MarketOverview({
       <div className="grid grid-cols-1 gap-6">
         {/* Utilization and APR Chart */}
         <UtilizationAPRChart
-          marketId={market.marketId!}
+          marketId={market.id}
           title="Utilization & APR"
           description="Compare utilization rate and APR trends"
           className={cardStyles}
         />
         {/* Supply and Borrow Chart */}
         <SupplyBorrowChart
-          marketId={market.marketId!}
+          marketId={market.id}
           title="Supply & Borrow"
           description="Compare total supply and borrow amounts over time"
           className={cardStyles}
-          symbol={market.loanTokenSymbol}
-          loanDecimals={market.loanTokenDecimals}
-          collateralDecimals={market.collateralTokenDecimals}
+          symbol={market.loan_token_symbol}
+          loanDecimals={market.loan_token_decimals}
+          collateralDecimals={market.collateral_token_decimals}
         />
       </div>
 
@@ -45,15 +45,15 @@ export function MarketOverview({
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-6">
         <InfoCard
           title="7D APY"
-          value={formatPercentage(wadToPercentage(market.borrowAPR))}
+          value={formatPercentage(wadToPercentage(market.borrow_apr))}
         />
         <InfoCard
           title="30D APY"
-          value={formatPercentage(wadToPercentage(market.borrowAPR))}
+          value={formatPercentage(wadToPercentage(market.borrow_apr))}
         />
         <InfoCard
           title="90D APY"
-          value={formatPercentage(wadToPercentage(market.borrowAPR))}
+          value={formatPercentage(wadToPercentage(market.borrow_apr))}
         />
       </div>
     </>

--- a/frontend/components/market-tabs.tsx
+++ b/frontend/components/market-tabs.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useMarketActivityQuery } from "@/app/(app)/borrow/queries-mutations"
-import { MarketInfo } from "@/app/types"
+import { Market } from "@/app/types"
 import { MarketOverview } from "@/components/market-overview"
 import { MyPosition } from "@/components/my-position"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -9,7 +9,7 @@ import { activityColumns } from "./activity-columns"
 import { DataTable } from "./ui/data-table"
 
 interface MarketTabsProps {
-  market: MarketInfo;
+  market: Market;
   apyVariations: {
     sevenDay: number;
     ninetyDay: number;
@@ -25,7 +25,7 @@ export function MarketTabs({
   caller
 }: MarketTabsProps) {
 
-  const { data: marketActivityResponse } = useMarketActivityQuery(market.poolPath!);
+  const { data: marketActivityResponse } = useMarketActivityQuery(market.pool_path);
 
   return (
     <Tabs defaultValue="overview" className="w-full">
@@ -60,7 +60,7 @@ export function MarketTabs({
       
       <TabsContent value="position" className="mt-0">
         <MyPosition
-          marketId={market.marketId!}
+          marketId={market.id}
           cardStyles={cardStyles}
           caller={caller}
         />

--- a/frontend/components/position-card.tsx
+++ b/frontend/components/position-card.tsx
@@ -1,11 +1,11 @@
-import { MarketInfo } from "@/app/types";
+import { Market } from "@/app/types";
 import { HealthBar } from "@/components/health-bar";
 import { Card, CardContent } from "@/components/ui/card";
 
 const CARD_STYLES = "bg-gray-700/60 border-none rounded-3xl"
 
 export interface PositionCardProps {
-  market: MarketInfo
+  market: Market
   supplyAmount?: string
   borrowAmount?: string
   repayAmount?: string
@@ -39,7 +39,7 @@ export function PositionCard({
     <Card className={CARD_STYLES}>
       <CardContent className="space-y-3 -mt-2">
         <div>
-          <div className="text-sm text-gray-400">My loan position ({market.loanTokenSymbol})</div>
+          <div className="text-sm text-gray-400">My loan position ({market.loan_token_symbol})</div>
           <div className="text-xl font-semibold text-gray-200">
             {currentBorrowAssets}
             {(borrowDelta > 0 || repayDelta > 0) && (
@@ -52,7 +52,7 @@ export function PositionCard({
           </div>
         </div>
         <div>
-          <div className="text-sm text-gray-400">My collateral position ({market.collateralTokenSymbol})</div>
+          <div className="text-sm text-gray-400">My collateral position ({market.collateral_token_symbol})</div>
           <div className="text-xl font-semibold text-gray-200">
             {currentCollateral}
             {(supplyDelta > 0 || withdrawDelta > 0) && (

--- a/frontend/components/position-chart-tabs.tsx
+++ b/frontend/components/position-chart-tabs.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { getUserBorrowHistory, getUserCollateralHistory } from '@/app/services/api.service'
-import { MarketInfo } from '@/app/types'
+import { Market } from '@/app/types'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { cn } from "@/lib/utils"
@@ -10,7 +10,7 @@ import { useQuery } from '@tanstack/react-query'
 interface PositionChartTabsProps {
   caller: string
   marketId: string
-  market: MarketInfo
+  market: Market
   cardStyles: string
 }
 
@@ -29,12 +29,12 @@ export function PositionChartTabs({ caller, marketId, market, cardStyles }: Posi
 
   // todo: fix collateral token decimals in the contract (it is 0)
   const mappedCollateral = collateralHistory.map(d => ({
-    value: d.value / Math.pow(10, market.loanTokenDecimals), //this should be collateralTokenDecimals but since it doesn't work we use this
+    value: d.value / Math.pow(10, market.loan_token_decimals), //this should be collateralTokenDecimals but since it doesn't work we use this
     timestamp: d.timestamp
   }));
 
   const mappedBorrow = borrowHistory.map(d => ({
-    value: d.value / Math.pow(10, market.loanTokenDecimals),
+    value: d.value / Math.pow(10, market.loan_token_decimals),
     timestamp: d.timestamp
   }));
 

--- a/frontend/components/repay-withdraw-panel.tsx
+++ b/frontend/components/repay-withdraw-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useApproveTokenMutation, usePositionQuery, useRepayMutation, useWithdrawCollateralMutation } from "@/app/(app)/borrow/queries-mutations"
 import { getAllowance } from "@/app/services/abci"
-import { MarketInfo } from "@/app/types"
+import { Market } from "@/app/types"
 import { PositionCard } from "@/components/position-card"
 import { SidePanelCard } from "@/components/side-panel-card"
 import { usePositionCalculations } from "@/hooks/use-position-calculations"
@@ -13,7 +13,7 @@ import { useForm } from "react-hook-form"
 import { formatUnits } from "viem"
 
 interface RepayWithdrawPanelProps {
-  market: MarketInfo
+  market: Market
 }
 
 export function RepayWithdrawPanel({
@@ -70,20 +70,20 @@ export function RepayWithdrawPanel({
     if (isRepayInputEmpty || isRepayTooManyDecimals || isRepayOverMax) return;
     
     const repayAmountInTokens = Number(repayAmount || "0");
-    const repayAmountInDenom = repayAmountInTokens * Math.pow(10, market.loanTokenDecimals);
+    const repayAmountInDenom = repayAmountInTokens * Math.pow(10, market.loan_token_decimals);
     
     try {
-      const currentAllowance = BigInt(await getAllowance(market.loanToken!, userAddress!));
+      const currentAllowance = BigInt(await getAllowance(market.loan_token, userAddress!));
       
       if (currentAllowance < BigInt(repayAmountInDenom)) {
         await approveTokenMutation.mutateAsync({
-          tokenPath: market.loanToken!,
+          tokenPath: market.loan_token,
           amount: repayAmountInDenom
         });
       }
       
       await repayMutation.mutateAsync({
-        marketId: market.poolPath!,
+        marketId: market.pool_path,
         userAddress: userAddress!,
         assets: repayAmountInDenom
       });
@@ -98,20 +98,20 @@ export function RepayWithdrawPanel({
     if (isWithdrawInputEmpty || isWithdrawTooManyDecimals || isWithdrawOverMax) return;
     
     const withdrawAmountInTokens = Number(withdrawAmount || "0");
-    const withdrawAmountInDenom = withdrawAmountInTokens * Math.pow(10, market.collateralTokenDecimals);
+    const withdrawAmountInDenom = withdrawAmountInTokens * Math.pow(10, market.collateral_token_decimals);
     
     try {
-      const currentAllowance = BigInt(await getAllowance(market.collateralToken!, userAddress!));
+      const currentAllowance = BigInt(await getAllowance(market.collateral_token, userAddress!));
       
       if (currentAllowance < BigInt(withdrawAmountInDenom)) {
         await approveTokenMutation.mutateAsync({
-          tokenPath: market.collateralToken!,
+          tokenPath: market.collateral_token,
           amount: withdrawAmountInDenom
         });
       }
       
       await withdrawCollateralMutation.mutateAsync({
-        marketId: market.poolPath!,
+        marketId: market.pool_path,
         userAddress: userAddress!,
         amount: withdrawAmountInDenom
       });
@@ -128,16 +128,16 @@ export function RepayWithdrawPanel({
       <SidePanelCard
         icon={ArrowUp}
         iconColor="text-blue-400"
-        title={`Repay Loan ${market.loanTokenSymbol}`}
+        title={`Repay Loan ${market.loan_token_symbol}`}
         register={register}
         fieldName="repayAmount"
-        tokenSymbol={market.loanTokenSymbol}
-        currentBalanceFormatted={formatUnits(currentBorrowAssets, market.loanTokenDecimals)}
+        tokenSymbol={market.loan_token_symbol}
+        currentBalanceFormatted={formatUnits(currentBorrowAssets, market.loan_token_decimals)}
         buttonMessage={repayButtonMessage}
         isButtonDisabled={isRepayInputEmpty || isRepayTooManyDecimals || isRepayOverMax || isRepayPending}
         isButtonPending={isRepayPending}
         onMaxClickAction={() => {
-          setValue("repayAmount", formatUnits(currentBorrowAssets, market.loanTokenDecimals));
+          setValue("repayAmount", formatUnits(currentBorrowAssets, market.loan_token_decimals));
         }}
         onSubmitAction={handleRepay}
         inputValue={repayAmount}
@@ -147,16 +147,16 @@ export function RepayWithdrawPanel({
       <SidePanelCard
         icon={Minus}
         iconColor="text-purple-400"
-        title={`Withdraw Collateral ${market.collateralTokenSymbol}`}
+        title={`Withdraw Collateral ${market.collateral_token_symbol}`}
         register={register}
         fieldName="withdrawAmount"
-        tokenSymbol={market.collateralTokenSymbol}
-        currentBalanceFormatted={formatUnits(currentCollateral, market.collateralTokenDecimals)}
+        tokenSymbol={market.collateral_token_symbol}
+        currentBalanceFormatted={formatUnits(currentCollateral, market.collateral_token_decimals)}
         buttonMessage={withdrawButtonMessage}
         isButtonDisabled={isWithdrawInputEmpty || isWithdrawTooManyDecimals || isWithdrawOverMax || isWithdrawPending}
         isButtonPending={isWithdrawPending}
         onMaxClickAction={() => {
-          setValue("withdrawAmount", formatUnits(currentCollateral, market.collateralTokenDecimals));
+          setValue("withdrawAmount", formatUnits(currentCollateral, market.collateral_token_decimals));
         }}
         onSubmitAction={handleWithdraw}
         inputValue={withdrawAmount}
@@ -168,8 +168,8 @@ export function RepayWithdrawPanel({
         repayAmount={repayAmount}
         withdrawAmount={withdrawAmount}
         healthFactor={healthFactor}
-        currentCollateral={formatUnits(currentCollateral, market.collateralTokenDecimals)}
-        currentBorrowAssets={formatUnits(currentBorrowAssets, market.loanTokenDecimals)}
+        currentCollateral={formatUnits(currentCollateral, market.collateral_token_decimals)}
+        currentBorrowAssets={formatUnits(currentBorrowAssets, market.loan_token_decimals)}
       />
     </form>
   )

--- a/frontend/components/side-panel.tsx
+++ b/frontend/components/side-panel.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { MarketInfo } from "@/app/types"
+import { Market } from "@/app/types"
 import { AddBorrowPanel } from "@/components/add-borrow-panel"
 import { RepayWithdrawPanel } from "@/components/repay-withdraw-panel"
 import { SupplyPanel } from "@/components/supply-panel"
@@ -18,7 +18,7 @@ import { WalletIcon } from "lucide-react"
 interface SidePanelProps {
   tab: string
   setTabAction: (tab: string) => void
-  market: MarketInfo
+  market: Market
 }
 
 export function SidePanel({

--- a/frontend/components/supply-panel.tsx
+++ b/frontend/components/supply-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useApproveTokenMutation, usePositionQuery, useSupplyMutation, useWithdrawMutation } from "@/app/(app)/borrow/queries-mutations"
 import { getAllowance, getTokenBalance } from "@/app/services/abci"
-import { MarketInfo } from "@/app/types"
+import { Market } from "@/app/types"
 import { calculateMaxWithdrawable } from "@/app/utils/position.utils"
 import { SidePanelCard } from "@/components/side-panel-card"
 import { useSupplyWithdrawValidation } from "@/hooks/use-supply-withdraw-validation"
@@ -12,7 +12,7 @@ import { useForm } from "react-hook-form"
 import { formatUnits } from "viem"
 
 interface SupplyPanelProps {
-  market: MarketInfo
+  market: Market
 }
 
 export function SupplyPanel({
@@ -26,7 +26,7 @@ export function SupplyPanel({
   })
 
   const { userAddress } = useUserAddress()
-  const { data: positionData } = usePositionQuery(market.poolPath!, userAddress)
+  const { data: positionData } = usePositionQuery(market.pool_path, userAddress)
   
   const maxWithdrawable = calculateMaxWithdrawable(positionData ?? {
     borrow_shares: "0",
@@ -63,20 +63,20 @@ export function SupplyPanel({
     if (isSupplyInputEmpty || isSupplyTooManyDecimals) return;
     
     const supplyAmountInTokens = Number(supplyAmount || "0");
-    const supplyAmountInDenom = supplyAmountInTokens * Math.pow(10, market.loanTokenDecimals);
+    const supplyAmountInDenom = supplyAmountInTokens * Math.pow(10, market.loan_token_decimals);
     
     try {
-      const currentAllowance = BigInt(await getAllowance(market.loanToken!, userAddress!));
+      const currentAllowance = BigInt(await getAllowance(market.loan_token, userAddress!));
       
       if (currentAllowance < BigInt(supplyAmountInDenom)) {
         await approveTokenMutation.mutateAsync({
-          tokenPath: market.loanToken!,
+          tokenPath: market.loan_token,
           amount: supplyAmountInDenom
         });
       }
       
       await supplyMutation.mutateAsync({
-        marketId: market.poolPath!,
+        marketId: market.pool_path,
         userAddress: userAddress!,
         assets: supplyAmountInDenom
       });
@@ -91,20 +91,20 @@ export function SupplyPanel({
     if (isWithdrawInputEmpty || isWithdrawTooManyDecimals || isWithdrawOverMax) return;
     
     const withdrawAmountInTokens = Number(withdrawAmount || "0");
-    const withdrawAmountInDenom = withdrawAmountInTokens * Math.pow(10, market.loanTokenDecimals);
+    const withdrawAmountInDenom = withdrawAmountInTokens * Math.pow(10, market.loan_token_decimals);
     
     try {
-      const currentAllowance = BigInt(await getAllowance(market.loanToken!, userAddress!));
+      const currentAllowance = BigInt(await getAllowance(market.loan_token, userAddress!));
       
       if (currentAllowance < BigInt(withdrawAmountInDenom)) {
         await approveTokenMutation.mutateAsync({
-          tokenPath: market.loanToken!,
+          tokenPath: market.loan_token,
           amount: withdrawAmountInDenom
         });
       }
       
       await withdrawMutation.mutateAsync({
-        marketId: market.poolPath!,
+        marketId: market.pool_path,
         userAddress: userAddress!,
         assets: withdrawAmountInDenom
       });
@@ -121,18 +121,18 @@ export function SupplyPanel({
       <SidePanelCard
         icon={Plus}
         iconColor="text-blue-400"
-        title={`Supply ${market.loanTokenSymbol}`}
+        title={`Supply ${market.loan_token_symbol}`}
         register={register}
         fieldName="supplyAmount"
-        tokenSymbol={market.loanTokenSymbol}
+        tokenSymbol={market.loan_token_symbol}
         currentBalanceFormatted="0.00"
         buttonMessage={supplyButtonMessage}
         isButtonDisabled={isSupplyInputEmpty || isSupplyTooManyDecimals || isSupplyPending}
         isButtonPending={isSupplyPending}
         onMaxClickAction={async () => {
           try {
-            const balance = await getTokenBalance(market.loanToken!, userAddress!);
-            const balanceFormatted = formatUnits(BigInt(balance), market.loanTokenDecimals);
+            const balance = await getTokenBalance(market.loan_token, userAddress!);
+            const balanceFormatted = formatUnits(BigInt(balance), market.loan_token_decimals);
             setValue("supplyAmount", balanceFormatted);
           } catch (error) {
             console.error("Failed to fetch loan balance:", error);
@@ -146,16 +146,16 @@ export function SupplyPanel({
       <SidePanelCard
         icon={ArrowDown}
         iconColor="text-purple-400"
-        title={`Withdraw ${market.loanTokenSymbol}`}
+        title={`Withdraw ${market.loan_token_symbol}`}
         register={register}
         fieldName="withdrawAmount"
-        tokenSymbol={market.loanTokenSymbol}
-        currentBalanceFormatted={formatUnits(maxWithdrawable, market.loanTokenDecimals)}
+        tokenSymbol={market.loan_token_symbol}
+        currentBalanceFormatted={formatUnits(maxWithdrawable, market.loan_token_decimals)}
         buttonMessage={withdrawButtonMessage}
         isButtonDisabled={isWithdrawInputEmpty || isWithdrawTooManyDecimals || isWithdrawOverMax || isWithdrawPending}
         isButtonPending={isWithdrawPending}
         onMaxClickAction={() => {
-          setValue("withdrawAmount", formatUnits(maxWithdrawable, market.loanTokenDecimals));
+          setValue("withdrawAmount", formatUnits(maxWithdrawable, market.loan_token_decimals));
         }}
         onSubmitAction={handleWithdraw}
         inputValue={withdrawAmount}

--- a/frontend/hooks/use-borrow-validation.ts
+++ b/frontend/hooks/use-borrow-validation.ts
@@ -1,4 +1,4 @@
-import { MarketInfo } from "@/app/types"
+import { Market } from "@/app/types"
 import { parseUnits } from "viem"
 
 /**
@@ -7,7 +7,7 @@ import { parseUnits } from "viem"
 export function useFormValidation(
   supplyAmount: string,
   borrowAmount: string,
-  market: MarketInfo,
+  market: Market,
   maxBorrow: bigint
 ) {
   const hasTooManyDecimals = (input: string, maxDecimals: number): boolean => {
@@ -18,10 +18,10 @@ export function useFormValidation(
     return decimalPart.length > maxDecimals
   }
 
-  const borrowAmountBI = parseUnits(borrowAmount || "0", market.loanTokenDecimals)
+  const borrowAmountBI = parseUnits(borrowAmount || "0", market.loan_token_decimals)
 
   const isSupplyInputEmpty = !supplyAmount || supplyAmount === "0"
-  const isSupplyTooManyDecimals = hasTooManyDecimals(supplyAmount, market.collateralTokenDecimals)
+  const isSupplyTooManyDecimals = hasTooManyDecimals(supplyAmount, market.collateral_token_decimals)
   const supplyButtonMessage = isSupplyInputEmpty 
     ? "Enter supply amount" 
     : isSupplyTooManyDecimals 
@@ -29,7 +29,7 @@ export function useFormValidation(
       : "Supply"
 
   const isBorrowInputEmpty = !borrowAmount || borrowAmount === "0"
-  const isBorrowTooManyDecimals = hasTooManyDecimals(borrowAmount, market.loanTokenDecimals)
+  const isBorrowTooManyDecimals = hasTooManyDecimals(borrowAmount, market.loan_token_decimals)
   const isBorrowOverMax = borrowAmountBI > maxBorrow
   const borrowButtonMessage = isBorrowInputEmpty
     ? "Enter borrow amount"

--- a/frontend/hooks/use-position-calculations.ts
+++ b/frontend/hooks/use-position-calculations.ts
@@ -1,20 +1,20 @@
-import { MarketInfo, Position } from "@/app/types"
+import { Market, Position } from "@/app/types"
 import { calculatePositionMetrics, toAssetsUp } from "@/app/utils/position.utils"
 
 /**
  * Custom hook that provides position calculations and formatted display values
  */
-export function usePositionCalculations(positionData: Position, market: MarketInfo) {
+export function usePositionCalculations(positionData: Position, market: Market) {
   const currentCollateral = BigInt(positionData.collateral_supply || "0")
   const currentBorrowSharesBI = BigInt(positionData.borrow_shares || "0")
 
   const positionMetrics = calculatePositionMetrics(positionData, market)
 
-  const currentBorrowAssets = currentBorrowSharesBI > BigInt(0) && market.totalBorrowShares && market.totalBorrowAssets
+  const currentBorrowAssets = currentBorrowSharesBI > BigInt(0) && market.total_borrow_shares && market.total_borrow
     ? toAssetsUp(
         currentBorrowSharesBI,
-        BigInt(market.totalBorrowAssets),
-        BigInt(market.totalBorrowShares)
+        BigInt(market.total_borrow),
+        BigInt(market.total_borrow_shares)
       )
     : BigInt(0)
 

--- a/frontend/hooks/use-repay-withdraw-validation.ts
+++ b/frontend/hooks/use-repay-withdraw-validation.ts
@@ -1,4 +1,4 @@
-import { MarketInfo } from "@/app/types"
+import { Market } from "@/app/types"
 import { parseUnits } from "viem"
 
 /**
@@ -7,7 +7,7 @@ import { parseUnits } from "viem"
 export function useRepayWithdrawValidation(
   repayAmount: string,
   withdrawAmount: string,
-  market: MarketInfo,
+  market: Market,
   currentBorrowAssets: bigint,
   currentCollateral: bigint
 ) {
@@ -19,11 +19,11 @@ export function useRepayWithdrawValidation(
     return decimalPart.length > maxDecimals
   }
 
-  const repayAmountBI = parseUnits(repayAmount || "0", market.loanTokenDecimals)
-  const withdrawAmountBI = parseUnits(withdrawAmount || "0", market.collateralTokenDecimals)
+  const repayAmountBI = parseUnits(repayAmount || "0", market.loan_token_decimals)
+  const withdrawAmountBI = parseUnits(withdrawAmount || "0", market.collateral_token_decimals)
 
   const isRepayInputEmpty = !repayAmount || repayAmount === "0"
-  const isRepayTooManyDecimals = hasTooManyDecimals(repayAmount, market.loanTokenDecimals)
+  const isRepayTooManyDecimals = hasTooManyDecimals(repayAmount, market.loan_token_decimals)
   const isRepayOverMax = repayAmountBI > currentBorrowAssets
   const repayButtonMessage = isRepayInputEmpty 
     ? "Enter repay amount" 
@@ -34,7 +34,7 @@ export function useRepayWithdrawValidation(
         : "Repay"
 
   const isWithdrawInputEmpty = !withdrawAmount || withdrawAmount === "0"
-  const isWithdrawTooManyDecimals = hasTooManyDecimals(withdrawAmount, market.collateralTokenDecimals)
+  const isWithdrawTooManyDecimals = hasTooManyDecimals(withdrawAmount, market.collateral_token_decimals)
   const isWithdrawOverMax = withdrawAmountBI > currentCollateral
   const withdrawButtonMessage = isWithdrawInputEmpty 
     ? "Enter withdraw amount" 

--- a/frontend/hooks/use-supply-withdraw-validation.ts
+++ b/frontend/hooks/use-supply-withdraw-validation.ts
@@ -1,30 +1,30 @@
-import { MarketInfo } from "@/app/types";
+import { Market } from "@/app/types";
 import { parseUnits } from "viem";
 
 export function useSupplyWithdrawValidation(
   supplyAmount: string,
   withdrawAmount: string,
-  market: MarketInfo,
+  market: Market,
   currentSupplyAssets: bigint
 ) {
-  const supplyAmountBigInt = supplyAmount ? parseUnits(supplyAmount, market.loanTokenDecimals) : BigInt(0);
-  const withdrawAmountBigInt = withdrawAmount ? parseUnits(withdrawAmount, market.loanTokenDecimals) : BigInt(0);
+  const supplyAmountBigInt = supplyAmount ? parseUnits(supplyAmount, market.loan_token_decimals) : BigInt(0);
+  const withdrawAmountBigInt = withdrawAmount ? parseUnits(withdrawAmount, market.loan_token_decimals) : BigInt(0);
 
   const isSupplyInputEmpty = !supplyAmount || supplyAmount === "0";
-  const isSupplyTooManyDecimals = supplyAmount.includes('.') && supplyAmount.split('.')[1].length > market.loanTokenDecimals;
+  const isSupplyTooManyDecimals = supplyAmount.includes('.') && supplyAmount.split('.')[1].length > market.loan_token_decimals;
   const supplyButtonMessage = isSupplyInputEmpty 
     ? "Enter supply amount" 
     : isSupplyTooManyDecimals
-      ? `Max ${market.loanTokenDecimals} decimals`
+      ? `Max ${market.loan_token_decimals} decimals`
       : "Supply";
 
   const isWithdrawInputEmpty = !withdrawAmount || withdrawAmount === "0";
-  const isWithdrawTooManyDecimals = withdrawAmount.includes('.') && withdrawAmount.split('.')[1].length > market.loanTokenDecimals;
+  const isWithdrawTooManyDecimals = withdrawAmount.includes('.') && withdrawAmount.split('.')[1].length > market.loan_token_decimals;
   const isWithdrawOverMax = withdrawAmountBigInt > currentSupplyAssets;
   const withdrawButtonMessage = isWithdrawInputEmpty 
     ? "Enter withdraw amount" 
     : isWithdrawTooManyDecimals
-      ? `Max ${market.loanTokenDecimals} decimals`
+      ? `Max ${market.loan_token_decimals} decimals`
       : isWithdrawOverMax 
         ? "Exceeds max withdrawable" 
         : "Withdraw";


### PR DESCRIPTION
- adds 2 second polling to current price (actually refetches whole market everywhere every 2 seconds)
- removes market info interface from types as it is redudant, uses just market type
- market type uses snake case instead of camel case so it is more present and typescript like now
- fixes gnoswap "swap" event not being registered